### PR TITLE
Update CLI docs: add analytics, fix profiles filter format, kebab-case flags

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4166,7 +4166,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Filter by wallet address"
+            "description": "Filter by wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
           },
           {
             "name": "expand",
@@ -4314,7 +4314,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Wallet address"
+            "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
           },
           {
             "name": "expand",
@@ -4524,7 +4524,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Wallet address (EVM 0x... or Solana base58)"
+            "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
           },
           { "$ref": "#/components/parameters/IdempotencyKey" }
         ],
@@ -4656,7 +4656,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Wallet address (EVM 0x... or Solana base58)"
+            "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
           },
           { "$ref": "#/components/parameters/IdempotencyKey" }
         ],
@@ -4745,7 +4745,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Wallet address (EVM 0x... or Solana base58)"
+            "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
           },
           { "$ref": "#/components/parameters/IdempotencyKey" }
         ],

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Formo Public API",
-    "description": "REST API for managing Formo projects, analytics, alerts, boards, charts, contracts, segments, and AI chat.\n\n**Auth.** All endpoints require a workspace API key with the appropriate scopes - see `x-api-scopes`.\n\n**Response shape.** Successful responses return the resource directly (or `{ data: [...], total, page, size, has_more }` for paginated lists). HTTP status carries success/failure - there is no envelope wrapping success bodies.\n\n**Errors.** Every non-2xx response uses the `Error` envelope: `{ error: { code, message, doc_url, param?, details? } }`. Branch on the machine-readable `code` (see `ErrorCode` enum) and follow `doc_url` to the matching section of the [errors reference](https://docs.formo.so/api/errors).\n\n**Idempotency.** Pass an `Idempotency-Key` header on POST/PUT/PATCH/DELETE to make retries safe; the response is cached for 24 h and replayed on duplicate keys.",
+    "description": "REST API for managing Formo projects, analytics, alerts, boards, charts, contracts, segments, and AI chat.\n\n**Auth.** All endpoints require a workspace API key with the appropriate scopes — see `x-api-scopes`.\n\n**Response shape.** Successful responses return the resource directly (or `{ data: [...], total, page, size, has_more }` for paginated lists). HTTP status carries success/failure — there is no envelope wrapping success bodies.\n\n**Errors.** Every non-2xx response uses the `Error` envelope: `{ error: { code, message, doc_url, param?, details? } }`. Branch on the machine-readable `code` (see `ErrorCode` enum) and follow `doc_url` to the matching section of the [errors reference](https://docs.formo.so/api/errors).\n\n**Idempotency.** Pass an `Idempotency-Key` header on POST/PUT/PATCH/DELETE to make retries safe; the response is cached for 24 h and replayed on duplicate keys.",
     "version": "0.1.0",
     "contact": {
       "name": "Formo",
@@ -73,7 +73,7 @@
               },
               "message": {
                 "type": "string",
-                "description": "Human-readable error description. Wording may change between releases - branch on `code`, not `message`."
+                "description": "Human-readable error description. Wording may change between releases — branch on `code`, not `message`."
               },
               "doc_url": {
                 "type": "string",
@@ -297,7 +297,7 @@
               "track",
               "decoded_log"
             ],
-            "description": "`event` - built-in page/connect/transaction events; `track` - custom tracked events; `decoded_log` - decoded smart-contract events."
+            "description": "`event` — built-in page/connect/transaction events; `track` — custom tracked events; `decoded_log` — decoded smart-contract events."
           },
           "event": {
             "type": "string",
@@ -436,7 +436,7 @@
               "open"
             ],
             "default": "closed",
-            "description": "**Funnel only.** `closed` - users must complete steps in strict order with no intervening events. `open` - users may complete steps in order but other events may occur between steps."
+            "description": "**Funnel only.** `closed` — users must complete steps in strict order with no intervening events. `open` — users may complete steps in order but other events may occur between steps."
           },
           "conversionWindow": {
             "$ref": "#/components/schemas/ConversionWindow",
@@ -460,7 +460,7 @@
           },
           "startStep": {
             "$ref": "#/components/schemas/FunnelStep",
-            "description": "**user_paths - required.** The event where the user flow begins."
+            "description": "**user_paths — required.** The event where the user flow begins."
           },
           "endStep": {
             "oneOf": [
@@ -471,7 +471,7 @@
                 "type": "null"
               }
             ],
-            "description": "**user_paths - optional.** The event where the user flow ends. If `null` the flow is open-ended."
+            "description": "**user_paths — optional.** The event where the user flow ends. If `null` the flow is open-ended."
           },
           "maxSteps": {
             "type": "integer",
@@ -522,7 +522,7 @@
           "query": {
             "type": "string",
             "minLength": 1,
-            "description": "SQL query that powers the chart.\n\n- **`funnel`** - pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`retention`** - can be omitted or pass `\"\"`; data is fetched from the retention pipe directly.\n- **All other types** - required; must be a valid SQL string."
+            "description": "SQL query that powers the chart.\n\n- **`funnel`** — pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`retention`** — can be omitted or pass `\"\"`; data is fetched from the retention pipe directly.\n- **All other types** — required; must be a valid SQL string."
           },
           "chart_type": {
             "type": "string",
@@ -557,7 +557,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Column name(s) used as Y axis metrics.\n\n- `bar` / `line` - at least 1 element required.\n- `pie` / `stacked` - exactly 1 element required."
+            "description": "Column name(s) used as Y axis metrics.\n\n- `bar` / `line` — at least 1 element required.\n- `pie` / `stacked` — exactly 1 element required."
           },
           "group_by": {
             "type": "string",
@@ -569,7 +569,7 @@
               "$ref": "#/components/schemas/FunnelStep"
             },
             "minItems": 2,
-            "description": "Ordered list of funnel steps. Required for `funnel` (minimum 2 steps).\n\nEach element is a `FunnelStep` - add property filters as extra keys on the step object (e.g. `\"rdns\": { \"op\": \"equals\", \"value\": \"io.metamask\" }`)."
+            "description": "Ordered list of funnel steps. Required for `funnel` (minimum 2 steps).\n\nEach element is a `FunnelStep` — add property filters as extra keys on the step object (e.g. `\"rdns\": { \"op\": \"equals\", \"value\": \"io.metamask\" }`)."
           },
           "settings": {
             "$ref": "#/components/schemas/ChartSettings"
@@ -596,7 +596,7 @@
           "query": {
             "type": "string",
             "minLength": 1,
-            "description": "SQL query that powers the chart.\n\n- **`funnel`** - pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`retention`** - can be omitted or pass `\"\"`; data is fetched from the retention pipe directly.\n- **All other types** - required; must be a valid SQL string."
+            "description": "SQL query that powers the chart.\n\n- **`funnel`** — pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`retention`** — can be omitted or pass `\"\"`; data is fetched from the retention pipe directly.\n- **All other types** — required; must be a valid SQL string."
           },
           "chart_type": {
             "type": "string",
@@ -631,7 +631,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Column name(s) used as Y axis metrics.\n\n- `bar` / `line` - at least 1 element required.\n- `pie` / `stacked` - exactly 1 element required."
+            "description": "Column name(s) used as Y axis metrics.\n\n- `bar` / `line` — at least 1 element required.\n- `pie` / `stacked` — exactly 1 element required."
           },
           "group_by": {
             "type": "string",
@@ -643,7 +643,7 @@
               "$ref": "#/components/schemas/FunnelStep"
             },
             "minItems": 2,
-            "description": "Ordered list of funnel steps. Required for `funnel` (minimum 2 steps).\n\nEach element is a `FunnelStep` - add property filters as extra keys on the step object (e.g. `\"rdns\": { \"op\": \"equals\", \"value\": \"io.metamask\" }`)."
+            "description": "Ordered list of funnel steps. Required for `funnel` (minimum 2 steps).\n\nEach element is a `FunnelStep` — add property filters as extra keys on the step object (e.g. `\"rdns\": { \"op\": \"equals\", \"value\": \"io.metamask\" }`)."
           },
           "settings": {
             "$ref": "#/components/schemas/ChartSettings"
@@ -1450,7 +1450,7 @@
       },
       "UpdateUserPropertiesResponse": {
         "type": "object",
-        "description": "Echo of the wallet identity after the merge-update applied. Synthesised from the request payload - analytics ingestion is eventually consistent, so the response reflects the applied write rather than a follow-up read.",
+        "description": "Echo of the wallet identity after the merge-update applied. Synthesised from the request payload — analytics ingestion is eventually consistent, so the response reflects the applied write rather than a follow-up read.",
         "required": [
           "address",
           "updated_at"
@@ -1900,7 +1900,7 @@
     },
     "responses": {
       "BadRequest": {
-        "description": "The request was rejected. `code` is either `INVALID_VALIDATION_REQUEST` (Zod schema mismatch - `details` carries a `{ fieldPath: message }` map) or `BAD_REQUEST` (semantic validation failure outside Zod, e.g. mismatched IDs, business-rule violations). Branch on `code`, not status, to tell the two apart.",
+        "description": "The request was rejected. `code` is either `INVALID_VALIDATION_REQUEST` (Zod schema mismatch — `details` carries a `{ fieldPath: message }` map) or `BAD_REQUEST` (semantic validation failure outside Zod, e.g. mismatched IDs, business-rule violations). Branch on `code`, not status, to tell the two apart.",
         "content": {
           "application/json": {
             "schema": {
@@ -3157,7 +3157,7 @@
                   }
                 },
                 "barChart": {
-                  "summary": "Daily active users - bar chart",
+                  "summary": "Daily active users — bar chart",
                   "value": {
                     "projectId": "proj_abc",
                     "query": "SELECT toDate(timestamp) AS date, countDistinct(address) AS users FROM events GROUP BY date ORDER BY date",
@@ -3170,7 +3170,7 @@
                   }
                 },
                 "lineChart": {
-                  "summary": "DAU last 30 days - line chart",
+                  "summary": "DAU last 30 days — line chart",
                   "value": {
                     "projectId": "proj_abc",
                     "query": "SELECT toDate(timestamp) AS date, countDistinct(address) AS daily_active_users FROM events GROUP BY date ORDER BY date DESC LIMIT 30",
@@ -3183,7 +3183,7 @@
                   }
                 },
                 "pieChart": {
-                  "summary": "Sessions by device - pie chart",
+                  "summary": "Sessions by device — pie chart",
                   "value": {
                     "projectId": "proj_abc",
                     "query": "SELECT device, COUNT(*) AS session_count FROM sessions GROUP BY device ORDER BY session_count DESC LIMIT 10",
@@ -3196,7 +3196,7 @@
                   }
                 },
                 "stackedChart": {
-                  "summary": "Sessions by device grouped by browser - stacked chart",
+                  "summary": "Sessions by device grouped by browser — stacked chart",
                   "value": {
                     "projectId": "proj_abc",
                     "query": "SELECT device, browser, COUNT(*) AS session_count FROM sessions GROUP BY device, browser ORDER BY session_count DESC",
@@ -3210,7 +3210,7 @@
                   }
                 },
                 "numberChart": {
-                  "summary": "Total connected wallets - number / KPI card",
+                  "summary": "Total connected wallets — number / KPI card",
                   "value": {
                     "projectId": "proj_abc",
                     "query": "SELECT COUNT(DISTINCT address) FROM events WHERE type = 'connect'",
@@ -3219,7 +3219,7 @@
                   }
                 },
                 "tableChart": {
-                  "summary": "Recent events - table",
+                  "summary": "Recent events — table",
                   "value": {
                     "projectId": "proj_abc",
                     "query": "SELECT * FROM events ORDER BY timestamp DESC LIMIT 10",
@@ -3228,7 +3228,7 @@
                   }
                 },
                 "userPathsChart": {
-                  "summary": "User flow from connect - max 5 steps",
+                  "summary": "User flow from connect — max 5 steps",
                   "value": {
                     "projectId": "proj_abc",
                     "query": "SELECT anonymous_id, type AS event, timestamp FROM events WHERE timestamp >= today() - INTERVAL 30 DAY ORDER BY anonymous_id, timestamp",
@@ -3269,12 +3269,12 @@
                   }
                 },
                 "retentionFiltered": {
-                  "summary": "Weekly retention - desktop users, transaction event",
+                  "summary": "Weekly retention — desktop users, transaction event",
                   "value": {
                     "projectId": "proj_abc",
                     "query": "",
                     "chart_type": "retention",
-                    "title": "Weekly Retention - Desktop",
+                    "title": "Weekly Retention — Desktop",
                     "settings": {
                       "retentionFilter": {
                         "type": "event",
@@ -4166,7 +4166,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Filter by wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
+            "description": "Filter by wallet address"
           },
           {
             "name": "expand",
@@ -4314,7 +4314,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
+            "description": "Wallet address"
           },
           {
             "name": "expand",
@@ -4524,7 +4524,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
+            "description": "Wallet address (EVM 0x... or Solana base58)"
           },
           { "$ref": "#/components/parameters/IdempotencyKey" }
         ],
@@ -4656,7 +4656,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
+            "description": "Wallet address (EVM 0x... or Solana base58)"
           },
           { "$ref": "#/components/parameters/IdempotencyKey" }
         ],
@@ -4745,7 +4745,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
+            "description": "Wallet address (EVM 0x... or Solana base58)"
           },
           { "$ref": "#/components/parameters/IdempotencyKey" }
         ],
@@ -4782,7 +4782,7 @@
         },
         "responses": {
           "204": {
-            "description": "Label deleted. No body - the caller already knows the new state."
+            "description": "Label deleted. No body — the caller already knows the new state."
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
@@ -4892,7 +4892,7 @@
         },
         "responses": {
           "200": {
-            "description": "Offset-paginated query results. The server doesn't own pagination here - `LIMIT` and `OFFSET` come from your SQL string and are echoed back. `total` is the row count before `LIMIT` was applied; `has_more` is true when there are additional rows beyond the current window.",
+            "description": "Offset-paginated query results. The server doesn't own pagination here — `LIMIT` and `OFFSET` come from your SQL string and are echoed back. `total` is the row count before `LIMIT` was applied; `has_more` is true when there are additional rows beyond the current window.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4926,7 +4926,7 @@
                     },
                     "has_more": {
                       "type": "boolean",
-                      "description": "True when `offset + data.length < total` - i.e. there's another page to fetch by re-running with a higher OFFSET."
+                      "description": "True when `offset + data.length < total` — i.e. there's another page to fetch by re-running with a higher OFFSET."
                     }
                   }
                 },
@@ -6762,7 +6762,7 @@
               "default": 10,
               "minimum": 0
             },
-            "description": "Minimum cohort size to include (default 10). Ignored when `user_filters` is set - all weeks are returned regardless of size."
+            "description": "Minimum cohort size to include (default 10). Ignored when `user_filters` is set — all weeks are returned regardless of size."
           },
           {
             "name": "limit",
@@ -6930,18 +6930,18 @@
         "x-required-scope": "query:read",
         "parameters": [
           {
-            "name": "dateFrom",
+            "name": "date_from",
             "in": "query",
             "required": true,
             "schema": {
               "type": "string",
               "format": "date"
             },
-            "description": "Inclusive ISO date for the start of the funnel window (YYYY-MM-DD). The events scan extends past `dateTo` by `window_seconds` so a user who fires step 1 just before `dateTo` can still complete the funnel inside their conversion window.",
+            "description": "Inclusive ISO date for the start of the funnel window (YYYY-MM-DD). The events scan extends past `date_to` by `window_seconds` so a user who fires step 1 just before `date_to` can still complete the funnel inside their conversion window.",
             "example": "2026-04-01"
           },
           {
-            "name": "dateTo",
+            "name": "date_to",
             "in": "query",
             "required": true,
             "schema": {
@@ -6958,10 +6958,10 @@
             "schema": {
               "type": "string"
             },
-            "description": "JSON-encoded array of 2-10 step specs. Each step is `{type, event, name, filters?: [{operand, operator, value}]}`. `type` is the event type (e.g. `event` for page views, `track` for custom events, `transaction`, `signature`, `decoded_log`). `event` is the event name. `name` is the unique step id (use `\"<event>::<index>\"` to disambiguate repeated events).\n\n**Filter operators:** `equals`, `notEquals`, `in`, `notIn`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `includes`. For `in`/`notIn`, pass the values as a `|`-separated string in `value` (e.g. `\"ethereum|polygon|base\"`).\n\n**Standard columns** (rendered via direct column access): `origin`, `device`, `browser`, `os`, `location`, `referrer`, `direct`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`, `version`, `locale`, `timezone`, `page_path`. Anything else is treated as a JSON property and read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
+            "description": "JSON-encoded array of 2–10 step specs. Each step is `{type, event, name, filters?: [{operand, operator, value}]}`. `type` is the event type (e.g. `event` for page views, `track` for custom events, `transaction`, `signature`, `decoded_log`). `event` is the event name. `name` is the unique step id (use `\"<event>::<index>\"` to disambiguate repeated events).\n\n**Filter operators:** `equals`, `notEquals`, `in`, `notIn`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `includes`. For `in`/`notIn`, pass the values as a `|`-separated string in `value` (e.g. `\"ethereum|polygon|base\"`).\n\n**Standard columns** (rendered via direct column access): `origin`, `device`, `browser`, `os`, `location`, `referrer`, `direct`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`, `version`, `locale`, `timezone`, `page_path`. Anything else is treated as a JSON property and read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
             "examples": {
               "simple": {
-                "summary": "Simple 3-step funnel - page to connect to swap",
+                "summary": "Simple 3-step funnel — page → connect → swap",
                 "value": "[{\"type\":\"event\",\"event\":\"page\",\"name\":\"page::0\",\"filters\":[]},{\"type\":\"track\",\"event\":\"connect\",\"name\":\"connect::1\",\"filters\":[]},{\"type\":\"track\",\"event\":\"swap\",\"name\":\"swap::2\",\"filters\":[]}]"
               },
               "standardColumnFilter": {
@@ -6981,7 +6981,7 @@
                 "value": "[{\"type\":\"track\",\"event\":\"connect\",\"name\":\"connect::0\",\"filters\":[{\"operand\":\"provider_name\",\"operator\":\"equals\",\"value\":\"MetaMask\"}]},{\"type\":\"track\",\"event\":\"swap\",\"name\":\"swap::1\",\"filters\":[]}]"
               },
               "jsonNumericFilter": {
-                "summary": "Step property filter using a numeric comparator (price > 100, JSONExtractFloat)",
+                "summary": "Step property filter using a numeric comparator (price > 100 → JSONExtractFloat)",
                 "value": "[{\"type\":\"track\",\"event\":\"swap\",\"name\":\"swap::0\",\"filters\":[{\"operand\":\"price\",\"operator\":\"gt\",\"value\":\"100\"}]},{\"type\":\"track\",\"event\":\"refund\",\"name\":\"refund::1\",\"filters\":[]}]"
               },
               "combinedFilters": {
@@ -7002,7 +7002,7 @@
               "default": 1209600,
               "minimum": 1
             },
-            "description": "Conversion window length in seconds. Defaults to 1,209,600 (14 days). For closed funnels this is the `windowFunnel` cap; for both variants the events scan is extended by this amount past `dateTo`.",
+            "description": "Conversion window length in seconds. Defaults to 1,209,600 (14 days). For closed funnels this is the `windowFunnel` cap; for both variants the events scan is extended by this amount past `date_to`.",
             "example": 86400
           },
           {
@@ -7013,7 +7013,7 @@
               "enum": ["closed", "open"],
               "default": "closed"
             },
-            "description": "`closed` (default) - ordered, in-window via `windowFunnel`. `open` - unordered per-step `minIf`; emits an extra `dropped_off_users` column."
+            "description": "`closed` (default) — ordered, in-window via `windowFunnel`. `open` — unordered per-step `minIf`; emits an extra `dropped_off_users` column."
           },
           {
             "name": "breakdown",
@@ -7144,14 +7144,14 @@
       "get": {
         "operationId": "getAnalyticsFlow",
         "summary": "Get session-scoped user-flow transitions (Sankey)",
-        "description": "Session-scoped user-flow transitions for Sankey-style charts. Given a required `start_step`, optional `end_step`, date window, conversion window, and max-step cap, returns one row per `(step, source, target)` transition with counts and per-step percentages.\n\n**How it works:** for each session that fires the start step inside `[dateFrom, dateTo]`, the pipe rebuilds the ordered sequence of subsequent events within the conversion window (`window_seconds`), normalises each event into a flow-node label (page path for `page`, event name for `track`/`decoded_log`, prefixed for `signature`/`transaction`), truncates at the first end-step match (when `end_step` is set), and slices to `max_steps + 1` nodes. Adjacent nodes are then exploded into `(step, source, target)` edges with counts and percentages.\n\n**Converter-only mode:** when `end_step` is set, only sessions that actually reached the end event within the window are kept, and the matched event is suffixed with `__END_MATCH__`. This mirrors PostHog's `pathsFilter.endPoint` behaviour - every visible link is part of a converting path.\n\n**Step shape:** `start_step` and `end_step` are JSON objects of shape `{type, event, resolved_event, filters?: [...], status_type?, status_value?}`. `resolved_event` is the value used to match against the events table (event name, page path, or the sentinel `__ALL_PAGE_VIEWS__` for any page view). `filters` and `global_filters` accept `{operand, operator, value, values?}` (use `values` for `in`/`notIn`).",
+        "description": "Session-scoped user-flow transitions for Sankey-style charts. Given a required `start_step`, optional `end_step`, date window, conversion window, and max-step cap, returns one row per `(step, source, target)` transition with counts and per-step percentages.\n\n**How it works:** for each session that fires the start step inside `[date_from, date_to]`, the pipe rebuilds the ordered sequence of subsequent events within the conversion window (`window_seconds`), normalises each event into a flow-node label (page path for `page`, event name for `track`/`decoded_log`, prefixed for `signature`/`transaction`), truncates at the first end-step match (when `end_step` is set), and slices to `max_steps + 1` nodes. Adjacent nodes are then exploded into `(step, source, target)` edges with counts and percentages.\n\n**Converter-only mode:** when `end_step` is set, only sessions that actually reached the end event within the window are kept, and the matched event is suffixed with `__END_MATCH__`. This mirrors PostHog's `pathsFilter.endPoint` behaviour — every visible link is part of a converting path.\n\n**Step shape:** `start_step` and `end_step` are JSON objects of shape `{type, event, resolved_event, filters?: [...], status_type?, status_value?}`. `resolved_event` is the value used to match against the events table (event name, page path, or the sentinel `__ALL_PAGE_VIEWS__` for any page view). `filters` and `global_filters` accept `{operand, operator, value, values?}` (use `values` for `in`/`notIn`).",
         "tags": [
           "Query"
         ],
         "x-required-scope": "query:read",
         "parameters": [
           {
-            "name": "dateFrom",
+            "name": "date_from",
             "in": "query",
             "required": true,
             "schema": {
@@ -7162,7 +7162,7 @@
             "example": "2026-04-01"
           },
           {
-            "name": "dateTo",
+            "name": "date_to",
             "in": "query",
             "required": true,
             "schema": {

--- a/cli/alerts.mdx
+++ b/cli/alerts.mdx
@@ -54,8 +54,8 @@ Requires `alerts:write` scope on your API key.
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `--name` | `string` | ✅ | Alert name |
-| `--triggerType` | `string` | ✅ | Trigger type (e.g. `event`, `threshold`) |
-| `--triggerFilters` | `string` | ❌ | JSON array of trigger filter objects |
+| `--trigger-type` | `string` | ✅ | Trigger type (e.g. `event`, `threshold`) |
+| `--trigger-filters` | `string` | ❌ | JSON array of trigger filter objects |
 | `--recipient` | `string` | ❌ | JSON array of recipient objects |
 | `--secret` | `string` | ❌ | Webhook secret for the alert |
 
@@ -63,19 +63,19 @@ Requires `alerts:write` scope on your API key.
 
 ```bash
 # Create a basic event alert
-formo alerts create --name "High value tx" --triggerType event
+formo alerts create --name "High value tx" --trigger-type event
 
 # Create an alert with trigger filters and recipients
 formo alerts create \
   --name "Whale activity" \
-  --triggerType threshold \
-  --triggerFilters '[{"field":"net_worth_usd","op":"gt","value":100000}]' \
+  --trigger-type threshold \
+  --trigger-filters '[{"field":"net_worth_usd","op":"gt","value":100000}]' \
   --recipient '[{"type":"email","value":"team@example.com"}]'
 
 # Create an alert with a webhook secret
 formo alerts create \
   --name "Transaction webhook" \
-  --triggerType event \
+  --trigger-type event \
   --secret "whsec_abc123"
 ```
 
@@ -100,8 +100,8 @@ Requires `alerts:write` scope on your API key.
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `--name` | `string` | ❌ | Alert name |
-| `--triggerType` | `string` | ❌ | Trigger type |
-| `--triggerFilters` | `string` | ❌ | JSON array of trigger filter objects |
+| `--trigger-type` | `string` | ❌ | Trigger type |
+| `--trigger-filters` | `string` | ❌ | JSON array of trigger filter objects |
 | `--recipient` | `string` | ❌ | JSON array of recipient objects |
 | `--secret` | `string` | ❌ | Webhook secret for the alert |
 
@@ -109,12 +109,12 @@ Requires `alerts:write` scope on your API key.
 
 ```bash
 # Update an alert name
-formo alerts update alert_abc123 --name "Renamed alert" --triggerType event
+formo alerts update alert_abc123 --name "Renamed alert" --trigger-type event
 
 # Update alert with new recipients
 formo alerts update alert_abc123 \
   --name "Updated alert" \
-  --triggerType threshold \
+  --trigger-type threshold \
   --recipient '[{"type":"slack","value":"#alerts"}]'
 ```
 

--- a/cli/analytics.mdx
+++ b/cli/analytics.mdx
@@ -41,7 +41,7 @@ Requires `query:read` scope on your API key.
 |--------|------|----------|-------------|
 | `--date-from` | `string` | ❌ | Inclusive start date `YYYY-MM-DD` (default: 7 days before `--date-to`) |
 | `--date-to` | `string` | ❌ | Inclusive end date `YYYY-MM-DD` (default: today) |
-| `--filters` | `string` | ❌ | JSON array of filter conditions: `[{"field","op","value"}]` |
+| `--filters` | `string` | ❌ | JSON array of filter conditions: `[{"field": "...", "op": "...", "value": "..."}]` |
 | `--params` | `string` | ❌ | JSON object of pipe-specific params merged into the query |
 
 <Note>

--- a/cli/analytics.mdx
+++ b/cli/analytics.mdx
@@ -1,0 +1,100 @@
+---
+title: "Analytics"
+sidebarTitle: "Analytics"
+icon: chart-mixed
+description: "Run Formo's pre-built analytics pipes — KPIs, funnels, retention, revenue, and top-N breakdowns — directly from the terminal, without writing SQL."
+---
+
+The `formo analytics` command exposes Formo's pre-built analytics pipes — the same data that powers the Formo dashboard — as terminal commands. Each pipe is a subcommand: `formo analytics <pipe>`.
+
+<Note>
+Requires `query:read` scope on your API key.
+</Note>
+
+## `formo analytics <pipe>`
+
+### Pipes
+
+| Pipe | Description |
+|------|-------------|
+| `kpis` | Traffic KPIs: visitors, pageviews, bounce rate, session duration |
+| `event_timeseries` | Event counts over time |
+| `funnel` | Conversion funnel across ordered steps |
+| `flow` | User path / flow analysis between steps |
+| `frequency` | Engagement frequency distribution |
+| `lifecycle` | User lifecycle stages (new, returning, power, resurrected, churned) |
+| `retention` | Retention cohort analysis |
+| `revenue_overview` | Revenue overview with optional breakdown |
+| `revenue_by_metric` | Revenue ranked by a metric column |
+| `revenue_timeseries` | Revenue over time (requires `address`) |
+| `volume_by_metric` | Trading volume ranked by a metric column |
+| `top_chains` | Top chains by activity |
+| `top_events` | Top events by count |
+| `top_locations` | Top locations |
+| `top_pages` | Top pages by traffic |
+| `top_sources` | Top acquisition sources |
+| `top_wallets` | Top wallets by activity |
+
+### Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `--date-from` | `string` | ❌ | Inclusive start date `YYYY-MM-DD` (default: 7 days before `--date-to`) |
+| `--date-to` | `string` | ❌ | Inclusive end date `YYYY-MM-DD` (default: today) |
+| `--filters` | `string` | ❌ | JSON array of filter conditions: `[{"field","op","value"}]` |
+| `--params` | `string` | ❌ | JSON object of pipe-specific params merged into the query |
+
+<Note>
+`--params` may **not** set `date_from`/`date_to`/`filters` — use the dedicated
+`--date-from`/`--date-to`/`--filters` flags for those. Object/array values in
+`--params` are JSON-encoded automatically (e.g. `funnel`'s `steps`).
+</Note>
+
+### `--filters`
+
+A JSON array of `{ field, op, value }` conditions, e.g. `[{"field":"location","op":"equals","value":"US"}]`. For multi-value matching, use `in` / `notIn` with a pipe-delimited `value` (e.g. `"chrome|firefox"`).
+
+### `--params` (pipe-specific)
+
+Some pipes take additional, pipe-specific parameters. Pass them as a JSON object via `--params`:
+
+| Pipe | Key params |
+|------|------------|
+| `kpis`, `revenue_overview` | `group_by`, `limit`, `include_previous_period` |
+| `funnel` | `steps` (required — JSON array of `{type,event,name,filters?}`), `window_seconds`, `funnel_type`, `breakdown` |
+| `flow` | `start_step` (required — JSON `{type,event,resolved_event,...}`), `end_step`, `global_filters`, `window_seconds`, `max_steps` |
+| `retention` | `id_type`, `event_type`, `event_name`, `min_users` |
+| `revenue_timeseries` | `address` (required) |
+| `revenue_by_metric`, `volume_by_metric`, `top_sources` | `metric_column`, `limit`, `offset` |
+| `top_chains`, `top_events`, `top_locations`, `top_pages`, `top_wallets` | `limit`, `offset` |
+
+### Examples
+
+```bash
+# Traffic KPIs for the last 7 days (default range)
+formo analytics kpis
+
+# KPIs for April 2026, broken down by device
+formo analytics kpis --date-from 2026-04-01 --date-to 2026-04-30 --params '{"group_by":"device"}'
+
+# Conversion funnel across ordered steps
+formo analytics funnel \
+  --date-from 2026-04-01 --date-to 2026-04-30 \
+  --params '{"steps":[{"type":"event","event":"page","name":"page::0","filters":[]},{"type":"track","event":"connect","name":"connect::1","filters":[]}],"window_seconds":86400}'
+
+# Top 10 wallets by activity last month
+formo analytics top_wallets --date-from 2026-04-01 --date-to 2026-04-30 --params '{"limit":10}'
+
+# Retention restricted to US visitors
+formo analytics retention --filters '[{"field":"location","op":"equals","value":"US"}]'
+
+# Revenue timeseries for a specific wallet
+formo analytics revenue_timeseries \
+  --date-from 2026-04-01 --date-to 2026-04-30 \
+  --params '{"address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"}'
+
+# Pipe results to jq for processing
+formo analytics kpis | jq '.data'
+```
+
+The response shape matches the dashboard data: `{ meta, data, rows, statistics }`.

--- a/cli/charts.mdx
+++ b/cli/charts.mdx
@@ -19,10 +19,10 @@ Requires `boards:read` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--boardId` | `string` | ✅ | Board ID to list charts from |
+| `--board-id` | `string` | ✅ | Board ID to list charts from |
 
 ```bash
-formo charts list --boardId board_abc123
+formo charts list --board-id board_abc123
 ```
 
 ---
@@ -45,10 +45,10 @@ Requires `boards:read` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--boardId` | `string` | ✅ | Board ID the chart belongs to |
+| `--board-id` | `string` | ✅ | Board ID the chart belongs to |
 
 ```bash
-formo charts get chart_abc123 --boardId board_abc123
+formo charts get chart_abc123 --board-id board_abc123
 ```
 
 ---
@@ -65,7 +65,7 @@ Requires `boards:write` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--boardId` | `string` | ✅ | Board ID to add the chart to |
+| `--board-id` | `string` | ✅ | Board ID to add the chart to |
 | `--body` | `string` | ✅ | JSON string with the chart configuration |
 
 ### Examples
@@ -73,12 +73,12 @@ Requires `boards:write` scope on your API key.
 ```bash
 # Create a line chart
 formo charts create \
-  --boardId board_abc123 \
+  --board-id board_abc123 \
   --body '{"name":"Daily active users","chartType":"line"}'
 
 # Create a bar chart with a SQL query
 formo charts create \
-  --boardId board_abc123 \
+  --board-id board_abc123 \
   --body '{"name":"Top chains","chartType":"bar","query":"SELECT chain, count(*) as cnt FROM events GROUP BY chain ORDER BY cnt DESC LIMIT 10"}'
 ```
 
@@ -102,7 +102,7 @@ Requires `boards:write` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--boardId` | `string` | ✅ | Board ID the chart belongs to |
+| `--board-id` | `string` | ✅ | Board ID the chart belongs to |
 | `--body` | `string` | ✅ | JSON string with updated chart configuration |
 
 ### Examples
@@ -110,12 +110,12 @@ Requires `boards:write` scope on your API key.
 ```bash
 # Update a chart name
 formo charts update chart_abc123 \
-  --boardId board_abc123 \
+  --board-id board_abc123 \
   --body '{"name":"Updated chart name"}'
 
 # Update chart type and query
 formo charts update chart_abc123 \
-  --boardId board_abc123 \
+  --board-id board_abc123 \
   --body '{"name":"Revenue","chartType":"area","query":"SELECT DATE(timestamp) as day, SUM(revenue) as rev FROM events GROUP BY day"}'
 ```
 
@@ -139,10 +139,10 @@ Requires `boards:write` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--boardId` | `string` | ✅ | Board ID the chart belongs to |
+| `--board-id` | `string` | ✅ | Board ID the chart belongs to |
 
 ```bash
-formo charts delete chart_abc123 --boardId board_abc123
+formo charts delete chart_abc123 --board-id board_abc123
 ```
 
 <Warning>

--- a/cli/import.mdx
+++ b/cli/import.mdx
@@ -20,7 +20,7 @@ Bulk import wallet addresses into the project.
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `--addresses` | `string` | ✅ | JSON array of wallet address strings to import |
-| `--writeKey` | `string` | ✅ | Project write SDK key |
+| `--write-key` | `string` | ✅ | Project write SDK key |
 
 ### Examples
 
@@ -28,12 +28,12 @@ Bulk import wallet addresses into the project.
 # Import two wallet addresses
 formo import wallets \
   --addresses '["0xabc123...","0xdef456..."]' \
-  --writeKey write_key_xxx
+  --write-key write_key_xxx
 
 # Import a list of addresses from a file (using jq)
 formo import wallets \
   --addresses "$(cat wallets.json)" \
-  --writeKey write_key_xxx
+  --write-key write_key_xxx
 ```
 
 ### Tips

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -14,6 +14,9 @@ The Formo CLI (`@formo/cli`) gives you full access to the Formo API from the com
   <Card title="Query" icon="database" href="/cli/query">
     Run SQL queries on my data
   </Card>
+  <Card title="Analytics" icon="chart-mixed" href="/cli/analytics">
+    Run pre-built analytics pipes (KPIs, funnels, retention, revenue)
+  </Card>
   <Card title="Charts" icon="chart-line" href="/cli/charts">
     Create and manage charts within custom dashboards
   </Card>

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -58,7 +58,7 @@ formo login formo_abc123
 formo profiles get vitalik.eth
 
 # 3. Run a SQL query
-formo query "SELECT count(*) FROM events"
+formo query run "SELECT count(*) FROM events"
 
 # 4. List your dashboard boards
 formo boards list

--- a/cli/profiles.mdx
+++ b/cli/profiles.mdx
@@ -69,13 +69,13 @@ Requires `profiles:read` scope on your API key.
 | `--address` | `string` | ❌ | Filter by wallet address |
 | `--page` | `number` | ❌ | Page number (1-indexed, default `1`) |
 | `--size` | `number` | ❌ | Page size (default `100`, max `1000`) |
-| `--orderBy` | `enum` | ❌ | Field to sort by (see values below) |
-| `--orderDir` | `enum` | ❌ | Sort direction: `asc` or `desc` |
+| `--order-by` | `enum` | ❌ | Field to sort by (see values below) |
+| `--order-dir` | `enum` | ❌ | Sort direction: `asc` or `desc` |
 | `--expand` | `string` | ❌ | Comma-separated fields to expand |
 | `--conditions` | `string` | ❌ | JSON array of `FilterCondition` objects for advanced filtering |
 | `--logic` | `enum` | ❌ | Logic operator for combining conditions: `and` (default) or `or` |
 
-### `--orderBy` values
+### `--order-by` values
 
 | Value | Description |
 |-------|-------------|
@@ -98,20 +98,25 @@ Requires `profiles:read` scope on your API key.
 formo profiles search --size 10
 
 # Top 5 profiles by net worth
-formo profiles search --orderBy net_worth_usd --orderDir desc --size 5
+formo profiles search --order-by net_worth_usd --order-dir desc --size 5
 
 # Get the second page of 20 profiles
 formo profiles search --page 2 --size 20
 
 # Search with a filter condition
 formo profiles search \
-  --conditions '[{"field":"net_worth_usd","op":"gt","value":10000}]' \
+  --conditions '[{"field":"users.net_worth_usd","op":"gt","value":10000}]' \
   --size 20
 
 # Search profiles matching either condition (OR logic)
 formo profiles search \
-  --conditions '[{"field":"net_worth_usd","op":"gt","value":10000},{"field":"tx_count","op":"gt","value":50}]' \
+  --conditions '[{"field":"users.net_worth_usd","op":"gt","value":10000},{"field":"users.volume","op":"gt","value":1000}]' \
   --logic or \
+  --size 20
+
+# Filter by on-chain balance on a specific chain (Ethereum = chain 1)
+formo profiles search \
+  --conditions '[{"field":"chains.1.balance","op":"gt","value":1000}]' \
   --size 20
 ```
 
@@ -123,16 +128,35 @@ The `--conditions` option accepts a JSON array of filter condition objects:
 
 ```json
 [
-  { "field": "net_worth_usd", "op": "gt", "value": 10000 },
-  { "field": "tx_count", "op": "gte", "value": 5 }
+  { "field": "users.net_worth_usd", "op": "gt", "value": 10000 },
+  { "field": "chains.1.balance", "op": "gte", "value": 1000 }
 ]
 ```
 
+<Warning>
+`field` **must be a typed path** (prefixed by its category — see the table
+below). A bare name like `net_worth_usd` is **silently ignored** by the API:
+no error is raised, no filtering is applied, and the search returns the entire
+unfiltered dataset. Always prefix the field, e.g. `users.net_worth_usd`.
+</Warning>
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `field` | `string` | Profile field to filter on |
+| `field` | `string` | Typed field path (see prefixes below) |
 | `op` | `string` | Operator (see table below) |
 | `value` | `any` | Value to compare against |
+| `scope` | `string` | _(token filters only)_ `any` or `protocol` |
+| `appId` | `string` | _(token filters with `scope: protocol`)_ e.g. `aave-v3` |
+
+### Field path prefixes
+
+| Prefix | Examples |
+|--------|----------|
+| `users.` | `users.net_worth_usd`, `users.volume`, `users.revenue`, `users.points`, `users.device`, `users.location`, `users.lifecycle`, `users.ens`, `users.farcaster` |
+| `chains.` | `chains.balance` (any chain), `chains.1.balance` (Ethereum) |
+| `apps.` | `apps.uniswap-v3.balance` |
+| `tokens.` | `tokens.0xA0b8…48.balance` |
+| `labels.` | `labels.coinbase.verified_account` |
 
 ### Filter operators
 
@@ -191,7 +215,7 @@ formo profiles update vitalik.eth \
 
 ## `formo profiles labels create`
 
-Upsert one or more labels on a wallet profile. Provide either a single label via `--tagId` or a batch via `--labels`.
+Upsert one or more labels on a wallet profile. Provide either a single label via `--tag-id` or a batch via `--labels`.
 
 <Note>
 Requires `profiles:write` scope on your API key.
@@ -207,20 +231,20 @@ Requires `profiles:write` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--tagId` | `string` | ❌ | Label identifier (e.g. `vip`, `airdrop_eligible`). Required unless `--labels` is provided. |
+| `--tag-id` | `string` | ❌ | Label identifier (e.g. `vip`, `airdrop_eligible`). Required unless `--labels` is provided. |
 | `--value` | `string` | ❌ | Optional label value (e.g. tier name, country code) |
-| `--chainId` | `string` | ❌ | Optional chain identifier the label applies to |
+| `--chain-id` | `string` | ❌ | Optional chain identifier the label applies to |
 | `--labels` | `string` | ❌ | JSON array of `UserLabelInput` objects for batch upsert |
 
 ### Examples
 
 ```bash
 # Tag a wallet as VIP
-formo profiles labels create 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --tagId vip
+formo profiles labels create 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --tag-id vip
 
 # Apply a tiered label scoped to a chain
 formo profiles labels create 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
-  --tagId tier --value gold --chainId 1
+  --tag-id tier --value gold --chain-id 1
 
 # Apply multiple labels in one call
 formo profiles labels create 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
@@ -239,7 +263,7 @@ formo profiles labels create 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
 
 ## `formo profiles labels delete`
 
-Delete a label from a wallet profile. Pass `--chainId` to scope the deletion to a chain-specific label.
+Delete a label from a wallet profile. Pass `--chain-id` to scope the deletion to a chain-specific label.
 
 <Note>
 Requires `profiles:write` scope on your API key.
@@ -255,16 +279,16 @@ Requires `profiles:write` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--tagId` | `string` | ✅ | Label identifier to delete |
-| `--chainId` | `string` | ❌ | Optional chain identifier to scope the deletion |
+| `--tag-id` | `string` | ✅ | Label identifier to delete |
+| `--chain-id` | `string` | ❌ | Optional chain identifier to scope the deletion |
 
 ### Examples
 
 ```bash
 # Remove the vip label
-formo profiles labels delete 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --tagId vip
+formo profiles labels delete 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --tag-id vip
 
 # Remove a chain-scoped label
 formo profiles labels delete 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
-  --tagId tier --chainId 1
+  --tag-id tier --chain-id 1
 ```

--- a/cli/profiles.mdx
+++ b/cli/profiles.mdx
@@ -135,9 +135,10 @@ The `--conditions` option accepts a JSON array of filter condition objects:
 
 <Warning>
 `field` **must be a typed path** (prefixed by its category — see the table
-below). A bare name like `net_worth_usd` is **silently ignored** by the API:
-no error is raised, no filtering is applied, and the search returns the entire
-unfiltered dataset. Always prefix the field, e.g. `users.net_worth_usd`.
+below). The CLI rejects a bare/untyped field (e.g. `net_worth_usd`) with an
+error, because the API would otherwise **silently ignore** it — no error, no
+filtering, returning the entire unfiltered dataset. Always prefix the field,
+e.g. `users.net_worth_usd`.
 </Warning>
 
 | Field | Type | Description |

--- a/cli/query.mdx
+++ b/cli/query.mdx
@@ -5,9 +5,9 @@ icon: database
 description: "Run ClickHouse SQL queries against your Formo analytics data warehouse directly from the terminal and output results in table, JSON, or CSV format."
 ---
 
-The `formo query` command lets you execute SQL queries against your Formo analytics data warehouse directly from the terminal.
+The `formo query run` command lets you execute SQL queries against your Formo analytics data warehouse directly from the terminal.
 
-## `formo query <sql>`
+## `formo query run <sql>`
 
 Run a SQL query against your Formo analytics data.
 
@@ -25,16 +25,16 @@ Requires `query:read` scope on your API key.
 
 ```bash
 # Count all events
-formo query "SELECT count(*) FROM events"
+formo query run "SELECT count(*) FROM events"
 
 # Top 10 wallets by net worth
-formo query "SELECT address, net_worth_usd FROM wallet_profiles ORDER BY net_worth_usd DESC LIMIT 10"
+formo query run "SELECT address, net_worth_usd FROM wallet_profiles ORDER BY net_worth_usd DESC LIMIT 10"
 
 # Daily active users over the last 7 days
-formo query "SELECT DATE(timestamp) as day, COUNT(DISTINCT address) as dau FROM events WHERE timestamp > now() - INTERVAL 7 DAY GROUP BY day ORDER BY day"
+formo query run "SELECT DATE(timestamp) as day, COUNT(DISTINCT address) as dau FROM events WHERE timestamp > now() - INTERVAL 7 DAY GROUP BY day ORDER BY day"
 
 # Pipe results to jq for processing
-formo query "SELECT count(*) as total FROM events" | jq '.data'
+formo query run "SELECT count(*) as total FROM events" | jq '.data'
 ```
 
 ### Tips

--- a/cli/segments.mdx
+++ b/cli/segments.mdx
@@ -34,7 +34,7 @@ Requires `segments:write` scope on your API key.
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `--title` | `string` | ✅ | Segment title |
-| `--filterSets` | `string` | ✅ | JSON array of filter set strings defining the segment |
+| `--filter-sets` | `string` | ✅ | JSON array of filter set strings defining the segment |
 
 ### Examples
 
@@ -42,12 +42,12 @@ Requires `segments:write` scope on your API key.
 # Create a high-value segment
 formo segments create \
   --title "Whales" \
-  --filterSets '["net_worth_usd > 100000"]'
+  --filter-sets '["net_worth_usd > 100000"]'
 
 # Create a power-user segment
 formo segments create \
   --title "Power Users" \
-  --filterSets '["tx_count > 100", "num_sessions > 10"]'
+  --filter-sets '["tx_count > 100", "num_sessions > 10"]'
 ```
 
 ---

--- a/docs.json
+++ b/docs.json
@@ -248,6 +248,7 @@
             "pages": [
               "cli/profiles",
               "cli/query",
+              "cli/analytics",
               "cli/boards",
               "cli/charts",
               "cli/alerts",


### PR DESCRIPTION
## Summary

Brings the CLI documentation in line with the latest `@formo/cli` implementation.

- **New `cli/analytics.mdx`** — documents the `formo analytics` command group: all 17 pre-built pipes (`kpis`, `funnel`, `flow`, `retention`, `revenue_*`, `top_*`, …), the shared `--date-from`/`--date-to`/`--filters` options, the generic `--params` JSON passthrough, per-pipe required params, and examples. Wired into `docs.json` nav and the overview card grid.
- **Profiles filter-format fix** — `profiles search --conditions` field paths must be **typed** (`users.net_worth_usd`, `chains.1.balance`, `tokens.{addr}.balance`, `labels.{tag}`). A bare name like `net_worth_usd` is silently ignored by the API (no error, no filtering, returns the entire dataset). Added a `<Warning>`, the field-path prefix table, and the `scope`/`appId` token-filter fields.
- **Kebab-case flags** — normalized every CLI flag reference (`--date-from`, `--order-by`, `--tag-id`, `--trigger-filters`, …) to match `incur --help` output and the Node/TS CLI ecosystem standard.

Pairs with the `@formo/cli` changes on `chore/update-api` (filter-bug fix, new `analytics` command, snake_case funnel/flow date params, kebab-case flags).

Note: ENS docs intentionally left unchanged — `6172c33` already documents ENS resolution support, which the separate profiles-API change will make accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->