### PR TITLE
P-2209: update `with-angular` and docs to use `@formo/analytics/core`

### DIFF
--- a/install.mdx
+++ b/install.mdx
@@ -643,14 +643,14 @@ Make sure you use the same `<SDK_WRITE_KEY>` for both your website and your app.
     Working example: [with-angular](https://github.com/getformo/examples/tree/main/with-angular). Also see the [Angular section](/sdks/web#angular) of the Web SDK page.
     </Note>
 
-    Angular has no first-class Formo binding — `FormoAnalyticsProvider` and `useFormo()` are React-only. Angular apps install Formo on the **non-wagmi, non-React path**: the framework-agnostic `FormoAnalytics.init()` core wrapped in an injectable service, with wallets connected over the bare EIP-1193 provider (`window.ethereum`).
+    Angular has no first-class Formo binding — `FormoAnalyticsProvider` and `useFormo()` are React-only. Angular apps install Formo on the **non-wagmi, non-React path**: import the framework-agnostic `FormoAnalytics.init()` core from the [`@formo/analytics/core`](https://github.com/getformo/sdk/releases/tag/v1.30.1) subpath (added in **v1.30.1**), wrap it in an injectable service, and connect wallets over the bare EIP-1193 provider (`window.ethereum`).
 
     #### 1. Install the Formo SDK
 
-    Install the SDK along with the `buffer` polyfill (Angular's esbuild build doesn't auto-polyfill Node globals, but the SDK uses `Buffer` to decode signed-message payloads) and viem:
+    Install the SDK (v1.30.1 or later) along with the `buffer` polyfill (Angular's esbuild build doesn't auto-polyfill Node globals, but the SDK uses `Buffer` to decode signed-message payloads) and viem:
 
     ```bash
-    pnpm add @formo/analytics buffer viem
+    pnpm add @formo/analytics@^1.30.1 buffer viem
     pnpm add -D @ngx-env/builder
     ```
 
@@ -662,24 +662,26 @@ Make sure you use the same `<SDK_WRITE_KEY>` for both your website and your app.
     (globalThis as unknown as { Buffer?: typeof Buffer }).Buffer ??= Buffer;
     ```
 
-    Reference it from `angular.json` and silence the SDK's React-re-export warnings:
+    Reference it from `angular.json`. Importing from `@formo/analytics/core` (step 2) keeps React out of the dependency graph, so only `viem` needs to be allowlisted for CommonJS:
 
     ```jsonc
     // angular.json (build > options)
     {
       "polyfills": ["src/polyfills.ts"],
-      "allowedCommonJsDependencies": ["react", "react/jsx-runtime", "react-dom", "viem"]
+      "allowedCommonJsDependencies": ["viem"]
     }
     ```
 
     #### 2. Wrap `FormoAnalytics.init()` in an injectable service
 
+    Import from `@formo/analytics/core` — the root entry re-exports the React provider, which Angular doesn't need:
+
     ```ts
     // src/app/services/formo-analytics.service.ts
 
     import { Injectable } from '@angular/core';
-    import { FormoAnalytics } from '@formo/analytics';
-    import type { IFormoAnalytics, IFormoEventProperties } from '@formo/analytics';
+    import { FormoAnalytics } from '@formo/analytics/core';
+    import type { IFormoAnalytics, IFormoEventProperties } from '@formo/analytics/core';
 
     @Injectable({ providedIn: 'root' })
     export class FormoAnalyticsService {

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -147,13 +147,13 @@ export default HomePage;
 ### Angular
 
 <Note>
-`FormoAnalyticsProvider` and `useFormo()` are React-only. Angular apps use the framework-agnostic `FormoAnalytics.init()` core, wrapped in an injectable service, with wallets connected over the bare EIP-1193 provider (`window.ethereum`). Full working example: [with-angular](https://github.com/getformo/examples/tree/main/with-angular).
+`FormoAnalyticsProvider` and `useFormo()` are React-only. Angular apps import from the React-free [`@formo/analytics/core`](https://github.com/getformo/sdk/releases/tag/v1.30.1) subpath (added in **v1.30.1**) and wrap `FormoAnalytics.init()` in an injectable service, with wallets connected over the bare EIP-1193 provider (`window.ethereum`). Full working example: [with-angular](https://github.com/getformo/examples/tree/main/with-angular).
 </Note>
 
-Install the Web SDK along with the `buffer` polyfill. Angular's esbuild build doesn't auto-polyfill Node globals, but the SDK uses `Buffer` to decode signed-message payloads — without it, signing throws `ReferenceError: Buffer is not defined`.
+Install the Web SDK (v1.30.1 or later) along with the `buffer` polyfill. Angular's esbuild build doesn't auto-polyfill Node globals, but the SDK uses `Buffer` to decode signed-message payloads — without it, signing throws `ReferenceError: Buffer is not defined`.
 
 ```bash
-npm install @formo/analytics buffer viem --save
+npm install @formo/analytics@^1.30.1 buffer viem --save
 ```
 
 ```ts
@@ -166,17 +166,17 @@ import { Buffer } from 'buffer';
 // angular.json (build > options)
 {
   "polyfills": ["src/polyfills.ts"],
-  "allowedCommonJsDependencies": ["react", "react/jsx-runtime", "react-dom", "viem"]
+  "allowedCommonJsDependencies": ["viem"]
 }
 ```
 
-Wrap `FormoAnalytics.init()` in an injectable service:
+Wrap `FormoAnalytics.init()` in an injectable service. Import from `@formo/analytics/core` — the root entry pulls in the React provider, which Angular doesn't need:
 
 ```ts
 // src/app/services/formo-analytics.service.ts
 import { Injectable } from '@angular/core';
-import { FormoAnalytics } from '@formo/analytics';
-import type { IFormoAnalytics, IFormoEventProperties } from '@formo/analytics';
+import { FormoAnalytics } from '@formo/analytics/core';
+import type { IFormoAnalytics, IFormoEventProperties } from '@formo/analytics/core';
 
 @Injectable({ providedIn: 'root' })
 export class FormoAnalyticsService {


### PR DESCRIPTION
## Summary

Updates the Angular install instructions in `sdks/web.mdx` and `install.mdx` for `@formo/analytics` v1.30.1, which introduces a React-free `./core` subpath. Angular consumers can now skip the React import graph entirely — `react`, `react-dom`, and `@types/react` are optional peer deps and never enter the bundle.

## Key Changes

- Swapped the Angular service imports from `@formo/analytics` to `@formo/analytics/core` for both the `FormoAnalytics` value and the `IFormoAnalytics` / `IFormoEventProperties` types
- Shrank `allowedCommonJsDependencies` in `angular.json` from `["react", "react/jsx-runtime", "react-dom", "viem"]` to `["viem"]` — the React entries only existed to silence CJS warnings from the root entry's React re-export, which `./core` doesn't trigger
- Pinned the install command to `@formo/analytics@^1.30.1` and updated the intro `<Note>` blocks to link the [v1.30.1 release](https://github.com/getformo/sdk/releases/tag/v1.30.1) and explain the `./core` entry point
- Left the `buffer` polyfill section intact — v1.30.1's `buildSignatureEventPayload` still calls `Buffer.from(...).toString("utf8")` for `personal_sign`, so esbuild consumers still hit `ReferenceError: Buffer is not defined` on the first signed message without it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->