### PR TITLE
docs: add per-event Properties sections and align event docs with SDK

### DIFF
--- a/data/events/chain.mdx
+++ b/data/events/chain.mdx
@@ -6,16 +6,22 @@ description: 'Reference for the chain event emitted when a user switches blockch
 The `chain` event is emitted whenever the user's chain network changes.
 It includes the chain ID the user switched to.
 
+## Properties
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `chain_id` | Number | Chain ID of the network the user switched to. |
+
 ## Sample Payload
 
 Here’s the payload of a typical call with most common fields removed:
 
 ```json
 {
-    "type": "chain", 
+    "type": "chain",
+    "address": "0x8e6ca77a7e044ba836a97beb796c124ca3a6a154",
     "properties": {
-        "chain_id": 1,
-        "address": "0x8e6ca77a7e044ba836a97beb796c124ca3a6a154"
+        "chain_id": 1
     }
 }
 ```

--- a/data/events/connect.mdx
+++ b/data/events/connect.mdx
@@ -6,6 +6,12 @@ description: 'Reference for the connect event emitted when a user connects their
 The `connect` event is emitted whenever the user connects a wallet.
 It includes the newly connected chain ID and wallet address of the user.
 
+## Properties
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `chain_id` | Number | Chain ID of the network the wallet connected to. |
+
 ## Sample Payload
 
 Here’s the payload of a typical call with most common fields removed:
@@ -13,9 +19,9 @@ Here’s the payload of a typical call with most common fields removed:
 ```json
 {
     "type": "connect",
+    "address": "0x8e6ca77a7e044ba836a97beb796c124ca3a6a154",
     "properties": {
-        "chain_id": 1,
-        "address": "0x8e6ca77a7e044ba836a97beb796c124ca3a6a154"
-    } 
+        "chain_id": 1
+    }
 }
 ```

--- a/data/events/detect.mdx
+++ b/data/events/detect.mdx
@@ -5,6 +5,13 @@ description: "Reference for the detect event that identifies a visitor's install
 
 The `detect` event lets you identify a visitor's wallet name and rdns.
 
+## Properties
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `provider_name` | String | Name of the detected wallet provider (e.g., MetaMask). |
+| `rdns` | String | Reverse-DNS identifier of the wallet provider (e.g., `io.metamask`). |
+
 ## Sample Payload
 
 Here’s the payload of a typical call with most common fields removed:

--- a/data/events/disconnect.mdx
+++ b/data/events/disconnect.mdx
@@ -6,16 +6,22 @@ description: 'Reference for the disconnect event emitted when a user disconnects
 The `disconnect` event is emitted whenever the user disconnects a wallet.
 It includes the disconnected chain ID and wallet address of the user.
 
+## Properties
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `chain_id` | Number | Chain ID of the network the wallet disconnected from. |
+
 ## Sample Payload
 
 Here’s the payload of a typical call with most common fields removed:
 
 ```json
 {
-    "type": "disconnect",  
+    "type": "disconnect",
+    "address": "0x8e6ca77a7e044ba836a97beb796c124ca3a6a154",
     "properties": {
-        "chain_id": 1,
-        "address": "0x8e6ca77a7e044ba836a97beb796c124ca3a6a154"
+        "chain_id": 1
     }
 }
 ```

--- a/data/events/identify.mdx
+++ b/data/events/identify.mdx
@@ -6,16 +6,23 @@ description: 'Reference for the identify event that ties users to their actions 
 The `identify` event lets you tie a user to their actions and record traits about them. 
 It includes a unique User ID, wallet name, and wallet rdns.
 
+## Properties
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `provider_name` | String | Name of the wallet provider (e.g., MetaMask). |
+| `rdns` | String | Reverse-DNS identifier of the wallet provider (e.g., `io.metamask`). |
+
 ## Sample Payload
 
 Here’s the payload of a typical call with most common fields removed:
 
 ```json
 {
-    "type": "identify",   
+    "type": "identify",
+    "user_id": "0c93652b-a366-4c92-ab87-0c0ab4fba5aa",
+    "address": "0x9798d87366bdfc5d70b300abdffc4f9e95369b3d",
     "properties": {
-        "user_id": "0c93652b-a366-4c92-ab87-0c0ab4fba5aa",
-        "address": "0x9798d87366bdfc5d70b300abdffc4f9e95369b3d",
         "provider_name": "MetaMask",
         "rdns": "io.metamask"
     }

--- a/data/events/overview.mdx
+++ b/data/events/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Event spec overview'
+title: 'Events overview'
 description: "Learn how to send event data to Formo's APIs and the correct format for capturing events with SDKs, including identify, track, connect, and transaction calls."
 ---
 
@@ -7,8 +7,8 @@ description: "Learn how to send event data to Formo's APIs and the correct forma
 
 The Events API supports the following event types, each capturing key touchpoints in the user journey:
 
-| API call | Description |
-| :------- | :---------- |
+| Event type | Description |
+| :--------- | :---------- |
 | [Identify](/data/events/identify) | Identifies a visitor or user |
 | [Detect](/data/events/detect) | Identifies a user's wallet provider |
 | [Track](/data/events/track) | Records a custom event with arbitrary data |

--- a/data/events/page.mdx
+++ b/data/events/page.mdx
@@ -7,32 +7,22 @@ The `page` event records whenever a user views a page on your website or a scree
 
 On web, page properties are automatically collected from the browser. On mobile, the screen name is mapped to page-equivalent fields (`page_title`, `page_path`, `page_url`) so that web and mobile views are processed through the same analytics pipeline.
 
-## Fields
-
-Apart from the [common fields](/data/events/common), the `page` call accepts the following properties:
-
-| Property | Type | Description |
-|:---------|:-----|:------------|
-| `url` | String | Full URL of the page. |
-| `path` | String | Path component of the URL (without query string or hash). |
-| `hash` | String | Hash fragment of the URL (e.g., `#section`). |
-| `query` | String | Query string of the URL (without the leading `?`). |
-| `name` | String | Name of the page or screen. |
-| `category` | String | Category of the page or screen. |
-| `title` | String | Title of the page. |
-
 ## Properties
 
-The following table shows which properties are automatically set by each SDK:
+| Property | Type | Description | Web SDK | Mobile SDK |
+|:---------|:-----|:------------|:--------|:-----------|
+| `url` | String | Full URL of the page. | `window.location.href` | Not set |
+| `path` | String | Path component of the URL (without query string or hash). | `window.location.pathname` | Not set |
+| `hash` | String | Hash fragment of the URL (e.g., `#section`). | `window.location.hash` | Not set |
+| `query` | String | Query string of the URL (without the leading `?`). | `window.location.search` | Not set |
+| `name` | String | Name of the page or screen. | Caller-provided | Screen name (required) |
+| `category` | String | Category of the page or screen. | Caller-provided | Caller-provided |
+| `title` | String | Title of the page. | Caller-provided | Not set |
 
-| Property | Web SDK | Mobile SDK |
-|:---------|:--------|:-----------|
-| `properties.url` | `window.location.href` | Not set |
-| `properties.path` | `window.location.pathname` | Not set |
-| `properties.hash` | `window.location.hash` | Not set |
-| `properties.query` | `window.location.search` | Not set |
-| `properties.name` | Caller-provided | Screen name (required) |
-| `properties.category` | Caller-provided | Caller-provided |
+On web, any non-UTM query-string parameters are also added as individual properties. The SDKs additionally auto-collect the following context fields:
+
+| Context field | Web SDK | Mobile SDK |
+|:--------------|:--------|:-----------|
 | `context.page_url` | `window.location.href` | `app://{screenName}` |
 | `context.page_title` | `document.title` | Screen name |
 | `context.page_path` | Not set (derived in backend) | Not set (derived in backend) |

--- a/data/events/signature.mdx
+++ b/data/events/signature.mdx
@@ -4,7 +4,15 @@ description: 'Reference for the signature event that tracks wallet message signi
 ---
 
 The `signature` event is emitted whenever the user signs a message.
-It includes the signature status (requested, rejected, confirmed), message, signature hash, chain ID, and wallet address.
+It includes the signature status (requested, rejected, confirmed), the signed message, chain ID, and wallet address.
+
+## Properties
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `status` | String | Signature request status: `requested`, `rejected`, or `confirmed`. |
+| `chain_id` | Number | Chain ID of the network. |
+| `message` | String | The message that was requested to be signed (e.g., a stringified EIP-712 typed-data payload). |
 
 ## Sample Payload
 
@@ -12,12 +20,12 @@ Here’s the payload of a typical call with most common fields removed:
 
 ```json
 {
-    "type": "signature", 
+    "type": "signature",
+    "address": "0x8e6ca77a7e044ba836a97beb796c124ca3a6a154",
     "properties": {
         "status": "confirmed",
         "chain_id": 84532,
-        "message": "{\"domain\":{\"name\":\"Example DApp\",\"version\":\"1\",\"chainId\":84532,\"verifyingContract\":\"0xcccccccccccccccccccccccccccccccccccccccc\"},\"message\":{\"from\":{\"name\":\"Alice\",\"wallet\":\"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\"},\"to\":{\"name\":\"Bob\",\"wallet\":\"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB\"},\"content\":\"zcvzxcvzxvc\"},\"primaryType\":\"Mail\",\"types\":{\"EIP712Domain\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\"}],\"Person\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"wallet\",\"type\":\"address\"}],\"Mail\":[{\"name\":\"from\",\"type\":\"Person\"},{\"name\":\"to\",\"type\":\"Person\"},{\"name\":\"content\",\"type\":\"string\"}]}}",
-        "address": "0x8e6ca77a7e044ba836a97beb796c124ca3a6a154"
+        "message": "{\"domain\":{\"name\":\"Example DApp\",\"version\":\"1\",\"chainId\":84532,\"verifyingContract\":\"0xcccccccccccccccccccccccccccccccccccccccc\"},\"message\":{\"from\":{\"name\":\"Alice\",\"wallet\":\"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\"},\"to\":{\"name\":\"Bob\",\"wallet\":\"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB\"},\"content\":\"zcvzxcvzxvc\"},\"primaryType\":\"Mail\",\"types\":{\"EIP712Domain\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\"}],\"Person\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"wallet\",\"type\":\"address\"}],\"Mail\":[{\"name\":\"from\",\"type\":\"Person\"},{\"name\":\"to\",\"type\":\"Person\"},{\"name\":\"content\",\"type\":\"string\"}]}}"
     }
 }
 ```

--- a/data/events/track.mdx
+++ b/data/events/track.mdx
@@ -1,9 +1,9 @@
 ---
-title: 'Track event'
-description: 'Reference for the Track API call used to record custom user actions like button clicks and purchases, with naming conventions and property schemas.'
+title: 'Custom events'
+description: 'Reference for the custom events used to record custom user actions and in-app behaviour.'
 ---
 
-The Track API call is how you record any [custom events](/features/product-analytics/custom-events) your users are doing, 
+Record any [custom events](/features/product-analytics/custom-events) in your app, 
 along with properties that describe the action. 
 
 Custom events can capture a broad range of actions, such as clicking a button or completing a purchase.
@@ -24,17 +24,24 @@ This allows everyone including you 6 months from now to instantly understand the
 
 Properties are additional information that give more clarity of your users' actions.
 
+Every custom event has `type` set to `track` and `event` set to your custom event name, with the event-specific data passed in the `properties` object:
+
+```json
+{
+  "type": "track",
+  "event": "Swap Reviewed",
+  "properties": {
+    "rating": 5
+  }
+}
+```
+
 Formo has reserved some standard properties listed in the following table and handles them in a special manner.
 
 ### Tracking volume, revenue, points
 
 You can track `volume`, `revenue`, and `points` in your events. 
 Once tracked, they are shown on the dashboard.
-
-<Frame caption="Revenue tracking.">
-	<img src="/images/revenue.png" alt="Revenue tracking." />
-</Frame>
-
 
 Include these optional properties in a custom event to track values associated with an action.
 
@@ -45,6 +52,9 @@ Include these optional properties in a custom event to track values associated w
 | `currency` | String | The currency of the revenue as a result of the event, set in ISO 4217 format. If this is not set, Formo assumes the revenue is in USD. |
 | `points` | String | An abstract value such as points or XP associated with an event, to be used by various teams. |
 
+<Frame caption="Revenue tracking.">
+	<img src="/images/revenue.png" alt="Revenue tracking." />
+</Frame>
 
 ## Sample Payload
 

--- a/data/events/track.mdx
+++ b/data/events/track.mdx
@@ -20,16 +20,6 @@ When naming events, Formo recommends establishing a consistent naming convention
 
 This allows everyone including you 6 months from now to instantly understand the meaning of an event.
 
-## Fields
-
-Apart from the [common fields](/data/events/common), the `track` call accepts the following fields:
-
-| Field | Type | Required | Description |
-|:------|:-----|:---------|:------------|
-| `event` | String | ✓ | Name of the user action |
-| `properties` | Object |  | Includes the properties associated with the event. For more information, check the Properties section below. |
-
-
 ## Properties
 
 Properties are additional information that give more clarity of your users' actions.

--- a/data/events/transaction.mdx
+++ b/data/events/transaction.mdx
@@ -4,13 +4,13 @@ description: 'Reference for the transaction event, including status tracking for
 ---
 
 The `transaction` event is emitted whenever the user performs a transaction.
-It includes the transaction status (started, broadcasted, rejected), to address, data, value, transaction hash, chain ID, and wallet address.
+It includes the transaction status (started, broadcasted, confirmed, rejected, reverted), to address, data, value, transaction hash, chain ID, and wallet address.
 
 ## Properties
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `status` | string | Transaction status: `started`, `broadcasted`, `confirmed`, or `rejected` |
+| `status` | string | Transaction status: `started`, `broadcasted`, `confirmed`, `rejected`, or `reverted` |
 | `chain_id` | number | Chain ID of the network |
 | `data` | string | Transaction calldata (hex-encoded) |
 | `to` | string | Recipient address |
@@ -19,6 +19,8 @@ It includes the transaction status (started, broadcasted, rejected), to address,
 | `function_name` | string | Decoded function name (if contract interaction) |
 | `function_args` | object | Decoded function arguments (if contract interaction) |
 | `builder_codes` | string | Comma-separated [builder codes](#builder-codes) extracted from the transaction calldata (ERC-8021) |
+
+Each entry in `function_args` is also flattened into the event's top-level properties for easier querying. For example, `function_args: { foo: "bar" }` also adds `foo: "bar"` as a property.
 
 ## Builder Codes
 


### PR DESCRIPTION
## Summary

Adds a `## Properties` section to every event page and aligns the event reference docs with the actual SDK implementation (`../sdk` — `EventFactory.ts`, `types/events.ts`).

## Changes

- **Per-event Properties tables** added to `page`, `identify`, `detect`, `connect`, `disconnect`, `chain`, and `signature`, listing the event-specific properties the SDK puts in the `properties` object.
- **page.mdx** — merged the old `## Fields` and `## Properties` sections into a single `## Properties` section, with the property table now carrying per-SDK source columns (Web SDK / Mobile SDK) and the remaining `context.*` rows kept as an auto-collection table.
- **Sample payloads** — moved `address` (and `user_id` for `identify`) to the top level, since the SDK emits them as common fields, not inside `properties`.
- **transaction.mdx** — corrected the `status` enum to the SDK's full set (added `reverted`); documented that decoded `function_args` are flattened into top-level properties.
- **signature.mdx** — removed the nonexistent "signature hash" from the prose.
- **track.mdx** — removed the `## Fields` section (its `event`/`properties` are top-level fields, already covered by common fields).
- **overview.mdx** — renamed the `API call` column to `Event type`; retitled the page to "Events overview".

## Notes

Content-only docs changes (`.mdx`). No code or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781945537&installation_id=130740768&pr_number=82&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F82&signature=231335d58237c44a3a9b7f83b2a035dc1891b7a1c1bb03e40099c83c4990a042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->