### PR TITLE
docs(profiles): add x402 and MPP agent access documentation

### DIFF
--- a/api/overview.mdx
+++ b/api/overview.mdx
@@ -23,8 +23,7 @@ You can use the Profiles API for real-time personalization. Once you fetch a pro
 - Fetch wallet profile properties including net worth and wallet labels
 - Segment and target users based on location, device, and referrer
 - Real-time activation API for personalized user experiences
-
-> Available on [x402](https://formo.x402.paysponge.com) on [MPP](https://formo.mpp.paysponge.com).
+- Also accessible by AI agents via [x402](https://www.x402.org/) (`formo.x402.paysponge.com`) and [MPP](https://mpp.dev/) (`formo.mpp.paysponge.com`) — pay per request, no API key required
 
 ## Query API
 

--- a/api/profiles/get.mdx
+++ b/api/profiles/get.mdx
@@ -4,11 +4,9 @@ description: 'Retrieve a comprehensive wallet profile by address, including onch
 openapi: 'GET /v0/profiles/{address}'
 ---
 
-Retrieves wallet profile information for a given address. Returns comprehensive profile data including wallet properties, labels, tokens, and apps. 
+Retrieves wallet profile information for a given address. Returns comprehensive profile data including wallet properties, labels, tokens, and apps.
 
 If you have Formo installed on your website and app, you will also get the user's web demographics (country, device, browser, operating system), lifecycle, volume, and revenue.
-
-> Available on [x402](https://formo.x402.paysponge.com) on [MPP](https://formo.mpp.paysponge.com).
 
 <Frame>
 	<img src="/images/profile-api-diagram.png" alt="Profiles API architecture diagram showing user device, Profiles API, and Wallet Profiles interaction" />
@@ -16,15 +14,94 @@ If you have Formo installed on your website and app, you will also get the user'
 
 ## Authentication
 
-This endpoint requires authentication using a **Workspace API Key** with `profiles:read` permission. Include the API key in your request headers:
+<Tabs>
+  <Tab title="Workspace API Key">
+    This endpoint requires a **Workspace API Key** with `profiles:read` permission. Include the API key in your request headers:
 
-```bash
-Authorization: Bearer <your_workspace_api_key>
-```
+    ```bash
+    Authorization: Bearer <your_workspace_api_key>
+    ```
 
-<Note>
-The API key needs to have the **read permission for profiles** in the API settings. You can configure this in your workspace API key settings.
-</Note>
+    ```bash
+    curl -sS \
+      -H "Authorization: Bearer <your_workspace_api_key>" \
+      "https://api.formo.so/v0/profiles/0x<address>"
+    ```
+
+    <Note>
+    Create a key with **profiles:read** scope in **Team Settings → API Keys**.
+    </Note>
+  </Tab>
+  <Tab title="x402 (AI agents)">
+    AI agents can access this endpoint through the **x402 gateway** — no Formo API key required. The agent pays per request using the [x402 protocol](https://www.x402.org/).
+
+    **Gateway URL:** `https://formo.x402.paysponge.com/v0/profiles/{address}`
+
+    **Price:** 0.05 USDC per request (Base network)
+
+    The gateway issues a `402 Payment Required` challenge on the first request. A compliant x402 client handles the payment automatically and retries with an `X-PAYMENT` header.
+
+    **Using the Sponge wallet SDK:**
+
+    ```typescript
+    import { SpongeWallet } from '@paysponge/sdk';
+
+    const wallet = new SpongeWallet({ apiKey: process.env.SPONGE_API_KEY });
+
+    const response = await wallet.x402Fetch({
+      url: 'https://formo.x402.paysponge.com/v0/profiles/0x<address>',
+      method: 'GET',
+    });
+
+    console.log(response.data); // wallet profile object
+    ```
+
+    **Raw HTTP (after payment):**
+
+    ```http
+    GET /v0/profiles/0x<address> HTTP/1.1
+    Host: formo.x402.paysponge.com
+    X-PAYMENT: <x402 payment payload>
+    ```
+
+    The response shape is identical to the standard endpoint. The `expand` query parameter works the same way.
+  </Tab>
+  <Tab title="MPP (AI agents)">
+    AI agents can also access this endpoint through the **MPP gateway** using the [MPP protocol](https://mpp.dev/).
+
+    **Gateway URL:** `https://formo.mpp.paysponge.com/v0/profiles/{address}`
+
+    **Price:** 0.05 USDC.e per request (Tempo network)
+
+    The gateway issues a `402 Payment Required` challenge. A compliant MPP client handles the payment authorization automatically.
+
+    **Using the mppx SDK:**
+
+    ```typescript
+    import { createTempoClient } from 'mppx';
+
+    const client = createTempoClient({
+      privateKey: process.env.TEMPO_PRIVATE_KEY,
+    });
+
+    const response = await client.fetch(
+      'https://formo.mpp.paysponge.com/v0/profiles/0x<address>',
+    );
+
+    const profile = await response.json();
+    ```
+
+    **Raw HTTP (after payment):**
+
+    ```http
+    GET /v0/profiles/0x<address> HTTP/1.1
+    Host: formo.mpp.paysponge.com
+    Authorization: Payment <mpp payment payload>
+    ```
+
+    The response shape is identical to the standard endpoint. The `expand` query parameter works the same way.
+  </Tab>
+</Tabs>
 
 ## Path parameters
 

--- a/api/profiles/get.mdx
+++ b/api/profiles/get.mdx
@@ -35,7 +35,10 @@ If you have Formo installed on your website and app, you will also get the user'
   <Tab title="x402">
     AI agents can access this endpoint through the **x402 gateway** with no Formo API key required. The agent pays per request using the [x402 protocol](https://www.x402.org/).
 
-    **Gateway URL:** `https://formo.x402.paysponge.com/v0/profiles/{address}`
+    **Gateway URL:**
+    ```
+    https://formo.x402.paysponge.com/v0/profiles/{address}
+    ```
 
     **Price:** 0.05 USDC per request (Base network)
 
@@ -69,7 +72,10 @@ If you have Formo installed on your website and app, you will also get the user'
   <Tab title="MPP">
     AI agents can also access this endpoint through the **MPP gateway** using the [MPP protocol](https://mpp.dev/).
 
-    **Gateway URL:** `https://formo.mpp.paysponge.com/v0/profiles/{address}`
+    **Gateway URL:**
+    ```
+    https://formo.mpp.paysponge.com/v0/profiles/{address}
+    ```
 
     **Price:** 0.05 USDC.e per request (Tempo network)
 

--- a/api/profiles/get.mdx
+++ b/api/profiles/get.mdx
@@ -25,31 +25,31 @@ If you have Formo installed on your website and app, you will also get the user'
     ```bash
     curl -sS \
       -H "Authorization: Bearer <your_workspace_api_key>" \
-      "https://api.formo.so/v0/profiles/0x<address>"
+      "https://api.formo.so/v0/profiles/<address>"
     ```
 
     <Note>
-    Create a key with **profiles:read** scope in **Team Settings → API Keys**.
+    Create a key with **profiles:read** scope in **Team Settings > API Keys**.
     </Note>
   </Tab>
-  <Tab title="x402 (AI agents)">
-    AI agents can access this endpoint through the **x402 gateway** — no Formo API key required. The agent pays per request using the [x402 protocol](https://www.x402.org/).
+  <Tab title="x402">
+    AI agents can access this endpoint through the **x402 gateway** with no Formo API key required. The agent pays per request using the [x402 protocol](https://www.x402.org/).
 
     **Gateway URL:** `https://formo.x402.paysponge.com/v0/profiles/{address}`
 
     **Price:** 0.05 USDC per request (Base network)
 
-    The gateway issues a `402 Payment Required` challenge on the first request. A compliant x402 client handles the payment automatically and retries with an `X-PAYMENT` header.
+    The gateway issues a `402 Payment Required` challenge on the first request. A compliant x402 client handles the payment automatically.
 
     **Using the Sponge wallet SDK:**
 
     ```typescript
     import { SpongeWallet } from '@paysponge/sdk';
 
-    const wallet = new SpongeWallet({ apiKey: process.env.SPONGE_API_KEY });
+    const wallet = await SpongeWallet.connect({ apiKey: process.env.SPONGE_API_KEY });
 
     const response = await wallet.x402Fetch({
-      url: 'https://formo.x402.paysponge.com/v0/profiles/0x<address>',
+      url: 'https://formo.x402.paysponge.com/v0/profiles/<address>',
       method: 'GET',
     });
 
@@ -59,14 +59,14 @@ If you have Formo installed on your website and app, you will also get the user'
     **Raw HTTP (after payment):**
 
     ```http
-    GET /v0/profiles/0x<address> HTTP/1.1
+    GET /v0/profiles/<address> HTTP/1.1
     Host: formo.x402.paysponge.com
-    X-PAYMENT: <x402 payment payload>
+    PAYMENT-SIGNATURE: <x402 payment payload>
     ```
 
     The response shape is identical to the standard endpoint. The `expand` query parameter works the same way.
   </Tab>
-  <Tab title="MPP (AI agents)">
+  <Tab title="MPP">
     AI agents can also access this endpoint through the **MPP gateway** using the [MPP protocol](https://mpp.dev/).
 
     **Gateway URL:** `https://formo.mpp.paysponge.com/v0/profiles/{address}`
@@ -85,7 +85,7 @@ If you have Formo installed on your website and app, you will also get the user'
     });
 
     const response = await client.fetch(
-      'https://formo.mpp.paysponge.com/v0/profiles/0x<address>',
+      'https://formo.mpp.paysponge.com/v0/profiles/<address>',
     );
 
     const profile = await response.json();
@@ -94,7 +94,7 @@ If you have Formo installed on your website and app, you will also get the user'
     **Raw HTTP (after payment):**
 
     ```http
-    GET /v0/profiles/0x<address> HTTP/1.1
+    GET /v0/profiles/<address> HTTP/1.1
     Host: formo.mpp.paysponge.com
     Authorization: Payment <mpp payment payload>
     ```


### PR DESCRIPTION
## Summary

- Replaces the bare `> Available on x402/MPP` note on the Get Profile page with a proper tabbed **Authentication** section covering all three access patterns: Workspace API Key, x402, and MPP
- Updates the API overview page to properly describe x402/MPP with gateway URLs

## Key Changes

- [`api/profiles/get.mdx`](api/profiles/get.mdx) — tabbed auth section with gateway URLs, price per request (0.05 USDC), Sponge SDK + mppx SDK code examples, and raw HTTP examples for both protocols
- [`api/overview.mdx`](api/overview.mdx) — Profiles API blurb updated to mention x402/MPP with links

## Test plan

- [ ] Run `npm run dev` locally and check `/api/profiles/get` renders the tabs correctly
- [ ] Verify code examples display cleanly in each tab
- [ ] Check overview page blurb renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783149109&installation_id=130740768&pr_number=84&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F84&signature=5e6645d7da1ef03f68a9168ef39acf9b38b60041a399d947ba065fd72707a3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->