### PR TITLE
Document user_profiles_mv and user_labels tables

### DIFF
--- a/data/catalog.mdx
+++ b/data/catalog.mdx
@@ -364,6 +364,43 @@ LIMIT 20
 
 ---
 
+### user_profiles_mv
+
+Project-scoped, first-party **user profile traits** captured from `identify` events. One row per `address`, holding the latest value of each trait. This is the identity-data counterpart to `wallet_profiles_mv` (which holds public onchain profile data); `user_profiles_mv` holds the traits *you* send.
+
+**Use cases:** User enrichment, first-party identity resolution, personalization, outreach
+
+<Warning>
+This is an **aggregate table** (`AggregatingMergeTree`). Each trait is stored as an aggregate state, so read it with `-Merge` functions (e.g. `argMaxIfMerge(email)`) and always `GROUP BY address`. Never use `SELECT *`. See [Working with Aggregate Tables](#working-with-aggregate-tables).
+</Warning>
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `address` | String | Wallet address (primary key within your project) |
+| `user_id` | String | Your own external user identifier |
+| `display_name` | String | Display name |
+| `email` | String | Email address |
+| `farcaster`, `discord`, `twitter`, `telegram`, `instagram`, `github`, `linkedin`, `facebook`, `tiktok`, `youtube`, `reddit` | String | Social handles |
+| `website` | String | Website URL |
+| `ens`, `lens`, `basenames`, `linea` | String | Web3 name-service handles |
+| `avatar` | String | Avatar image URL |
+| `description` | String | Bio / description |
+| `location` | String | Location |
+| `updated_at` | DateTime | Last time any trait was updated |
+
+**Example:**
+
+```sql
+SELECT
+    address,
+    argMaxIfMerge(display_name) AS display_name,
+    argMaxIfMerge(email) AS email
+FROM user_profiles_mv
+GROUP BY address
+```
+
+---
+
 ### wallet_profiles_mv
 
 Global wallet profile data aggregated across all chains. One row per wallet address with social profiles, contact info, and net worth.
@@ -509,6 +546,23 @@ Wallet labels and tags for categorizing and filtering wallet addresses. Each row
 
 ---
 
+### user_labels
+
+Project-scoped **labels and tags you assign to wallet addresses** (e.g. your own segments, scores, or categories). The latest value per `(tag_id, address, chain_id)` is kept automatically. This is the project-specific counterpart to `wallet_profiles_labels`, which holds **global** labels supplied by Formo's wallet profiler.
+
+**Use cases:** Custom segmentation, scoring, audience building, tagging
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `address` | String | Labeled wallet address |
+| `chain_id` | String | Chain the label applies to (`-` for all chains) |
+| `tag_id` | String | Label / tag identifier |
+| `value` | String | Optional label value or score |
+| `source` | String | System that supplied the label |
+| `timestamp` | DateTime | When the label was last updated |
+
+---
+
 ## Table relationships
 
 ```
@@ -646,7 +700,7 @@ ORDER BY date
 
 ## Working with aggregate tables
 
-Several tables (`users`, `anonymous_users`, `sessions`, `sources`, `identities`) use ClickHouse [AggregateFunction](https://clickhouse.com/docs/en/sql-reference/data-types/aggregatefunction) types. These store intermediate aggregation states, not final values.
+Several tables (`users`, `anonymous_users`, `sessions`, `sources`, `identities`, `user_profiles_mv`) use ClickHouse [AggregateFunction](https://clickhouse.com/docs/en/sql-reference/data-types/aggregatefunction) types. These store intermediate aggregation states, not final values.
 
 ### Rules
 
@@ -660,6 +714,7 @@ Several tables (`users`, `anonymous_users`, `sessions`, `sources`, `identities`)
 | Aggregate Type | Query Pattern | Example |
 |---------------|--------------|---------|
 | `AggregateFunction(argMax, T, DateTime)` | `argMaxMerge(col)` | `argMaxMerge(location)` |
+| `AggregateFunction(argMaxIf, T, DateTime, UInt8)` | `argMaxIfMerge(col)` | `argMaxIfMerge(email)` |
 | `AggregateFunction(argMin, T, DateTime)` | `argMinMerge(col)` | `argMinMerge(first_utm_source)` |
 | `AggregateFunction(uniq, T)` | `uniqMerge(col)` | `uniqMerge(num_sessions)` |
 | `AggregateFunction(count)` | `countMerge(col)` | `countMerge(hits)` |


### PR DESCRIPTION
## Summary
Added documentation for two new project-scoped data tables: `user_profiles_mv` (first-party user profile traits from identify events) and `user_labels` (custom labels and tags assigned to wallet addresses). Updated the aggregate tables reference to include `user_profiles_mv` and document the `argMaxIfMerge` function pattern.

## Changes
- **Added `user_profiles_mv` table documentation** with full column reference, use cases, and example query showing proper aggregate table usage with `-Merge` functions
- **Added `user_labels` table documentation** with column definitions and use cases for custom segmentation and scoring
- **Updated aggregate tables section** to include `user_profiles_mv` in the list of tables using ClickHouse AggregateFunction types
- **Added `argMaxIfMerge` pattern** to the aggregate function reference table to document the conditional max aggregation function

## Implementation details
- `user_profiles_mv` is documented as an `AggregatingMergeTree` with a warning to use `-Merge` functions and `GROUP BY address`
- `user_labels` is positioned as the project-specific counterpart to the global `wallet_profiles_labels` table
- Both tables are placed in logical positions within the catalog (user_profiles_mv before wallet_profiles_mv, user_labels after wallet_profiles_labels)

https://claude.ai/code/session_01XeF9u7YLwBCXtsADz9esGH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784786879&installation_id=130740768&pr_number=88&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F88&signature=325fe13e46c7c5809056b53351247d3df6e7c766de94eaac703509327de5ffcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->