### PR TITLE
fix(nav): restore Overview tab navigation broken by Dune link entry

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -64,14 +64,7 @@
               {
                 "group": "Integrations",
                 "icon": "plug",
-                "pages": [
-                  "integrations/overview",
-                  {
-                    "anchor": "Dune",
-                    "icon": "database",
-                    "href": "integrations/dune"
-                  }
-                ]
+                "pages": ["integrations/overview", "integrations/dune"]
               },
               "chains/overview"
             ]


### PR DESCRIPTION
The Dune integration (#92) added Dune to the Overview tab's sidebar as an external-link object (anchor/href) pointing at a relative internal path:

  { "anchor": "Dune", "icon": "database", "href": "integrations/dune" }

Mintlify anchor/href entries are for external URLs; a relative internal path there is malformed and broke the Overview tab's entire navigation tree. Symptoms: clicking the Overview tab did nothing, /intro rendered under the Guides sidebar, and the site root redirected to Guides.

Replace the link object with a normal page entry. integrations/dune.mdx already has sidebarTitle "Dune" and its own icon, so it renders correctly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994082&installation_id=130740768&pr_number=94&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F94&signature=8086d16323c2ca3ecb29022409f8783fc1bc31beffa11dd4b9a0fe9e8449b119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->