### PR TITLE
docs(integrations): remove sidebar icons from Overview and Dune

### DIFF
--- a/integrations/dune.mdx
+++ b/integrations/dune.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Dune"
 sidebarTitle: "Dune"
-icon: circle-half-stroke
 description: "Query on-chain data from Dune directly in your Formo dashboards and SQL Explorer, alongside your Formo analytics data."
 keywords: ["Dune", "Dune Analytics", "on-chain data", "Trino", "DuneSQL", "crypto SQL", "web3 analytics"]
 ---

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'Overview'
-icon: puzzle-piece
 description: 'Browse supported wallet providers, developer tools, and blockchain networks that integrate with Formo for analytics and event tracking.'
 ---
 


### PR DESCRIPTION
Drop the icon frontmatter (puzzle-piece, circle-half-stroke) from the Integrations overview and Dune pages so they render as plain sidebar entries, matching the Product Analytics pages.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994410&installation_id=130740768&pr_number=95&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F95&signature=a2f930e195888bffa7f3090133f37e348a02aaca92087374f08aa37109bf135e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->