### PR TITLE
docs(rbac): reconcile role matrix with current implementation

### DIFF
--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -32,7 +32,7 @@ Formo uses workspace roles to control what each teammate can view or change.
 | Verify projects | ✅ | ✅ | ✅ | ✅ |
 | Access project settings page | ✅ | ✅ | ✅ | ❌ |
 | Create & rename projects | ✅ | ✅ | ❌ | ❌ |
-| Manage project integrations (Dune SQL) | ✅ | ✅ | ❌ | ❌ |
+| Manage project integrations | ✅ | ✅ | ❌ | ❌ |
 | Manage project notifications | ✅ | ✅ | ❌ | ❌ |
 | Edit lifecycle thresholds | ✅ | ✅ | ❌ | ❌ |
 | Delete projects | ✅ | ❌ | ❌ | ❌ |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -8,8 +8,8 @@ icon: "users"
 
 - **Owner**: The creator of the team with full control over all aspects. Can transfer ownership and delete the team. Only one owner per team.
 - **Admin**: Help with managing the team. Can manage members, roles, workspace settings, and API keys / MCP, but cannot transfer ownership or delete the team.
-- **Editor**: Build and explore content. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL query editor and wallet search), import wallets, and edit user profile properties and labels. Can open project settings to manage contracts, alerts, and lifecycle, but cannot manage members or roles, cannot access workspace settings or API keys / MCP, and cannot create or delete projects.
-- **Member**: Read-only access to view content and analytics. Cannot use the Explorer, create dashboards, or edit user profile properties and labels, and cannot view the members list, workspace or project settings, or API keys / MCP.
+- **Editor**: Build and explore content. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL editor and wallet search), import wallets, edit user profile properties and labels, and manage agent memory. Can open project settings to manage contracts, alerts, and lifecycle, but cannot manage members or roles, cannot access workspace settings or API keys / MCP, and cannot create or delete projects.
+- **Member**: Read-only access to view content and analytics. Cannot use the Explorer, create dashboards, or edit user profile properties and labels, and cannot view the members list, workspace or project settings, agent memory, or API keys / MCP.
 
 ## User Roles and Permissions
 
@@ -33,7 +33,7 @@ icon: "users"
 | View projects | ✅ | ✅ | ✅ | ✅ |
 | Verify projects | ✅ | ✅ | ✅ | ✅ |
 | Access project settings page | ✅ | ✅ | ✅ | ❌ |
-| Create and edit projects (name, allowed URLs) | ✅ | ✅ | ❌ | ❌ |
+| Create and edit project settings | ✅ | ✅ | ❌ | ❌ |
 | Edit lifecycle thresholds | ✅ | ✅ | ✅ | ❌ |
 | Delete projects | ✅ | ❌ | ❌ | ❌ |
 | **Segments** | | | | |
@@ -41,9 +41,13 @@ icon: "users"
 | Create, delete, edit project segments | ✅ | ✅ | ✅ | ❌ |
 | **Charts, Dashboards & Explorer** | | | | |
 | View charts and dashboards | ✅ | ✅ | ✅ | ✅ |
-| Access the Explorer (SQL query editor and wallet search) | ✅ | ✅ | ✅ | ❌ |
+| Explorer (SQL editor and wallet search) | ✅ | ✅ | ✅ | ❌ |
 | Create, delete, edit charts | ✅ | ✅ | ✅ | ❌ |
 | Create dashboards | ✅ | ✅ | ✅ | ❌ |
+| **Users & Wallets** | | | | |
+| View wallet profiles | ✅ | ✅ | ✅ | ✅ |
+| Import wallet addresses | ✅ | ✅ | ✅ | ❌ |
+| Edit user profile properties and labels | ✅ | ✅ | ✅ | ❌ |
 | **Contracts** | | | | |
 | View project contracts | ✅ | ✅ | ✅ | ✅ |
 | Create, edit, delete project contracts | ✅ | ✅ | ✅ | ❌ |
@@ -51,14 +55,16 @@ icon: "users"
 | **Alerts** | | | | |
 | View project alerts | ✅ | ✅ | ✅ | ✅ |
 | Create, delete, edit project alerts | ✅ | ✅ | ✅ | ❌ |
-| **Users & Wallets** | | | | |
-| View user and wallet profiles | ✅ | ✅ | ✅ | ✅ |
-| Import wallet addresses | ✅ | ✅ | ✅ | ❌ |
-| Edit user profile properties and labels | ✅ | ✅ | ✅ | ❌ |
 | **Data & Access** | | | | |
-| Access API keys / MCP | ✅ | ✅ | ❌ | ❌ |
+| Manage API Keys | ✅ | ✅ | ❌ | ❌ |
+| MCP | ✅ | ✅ | ❌ | ❌ |
 | Create BI auth tokens | ✅ | ✅ | ❌ | ❌ |
 | View audit logs | ✅ | ✅ | ❌ | ❌ |
 | **Agent Memory (Ask AI)** | | | | |
-| View agent memory | ✅ | ✅ | ✅ | ✅ |
-| Curate / manage agent memory | ✅ | ✅ | ✅ | ❌ |
+| Manage agent memory | ✅ | ✅ | ✅ | ❌ |
+
+<Note>
+Owners implicitly have every permission. Admins have all workspace- and
+project-management permissions **except** transferring ownership, deleting the
+workspace, and deleting projects.
+</Note>

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -9,7 +9,7 @@ icon: "users"
 Formo uses workspace roles to control what each teammate can view or change.
 
 - **Owner**: Full access to the workspace. Owners can transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
-- **Admin**: Can manage the workspace, projects, and forms. Ownership transfer and destructive deletion remain owner-only.
+- **Admin**: Can manage the workspace, projects, and forms. Can manage members, roles, and settings but cannot transfer ownership or delete the team.
 - **Editor**: Can manage day-to-day project content, including forms, contracts, charts, dashboards, and alerts. Editors cannot manage workspace settings or projects themselves.
 - **Member**: Read-only access to projects and analytics. Members cannot make changes.
 

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Role Based Access Control (RBAC)"
-description: "Manage team permissions with role-based access control. Assign Owner, Admin, or Member roles to enforce least-privilege access across your workspace."
+description: "Manage team permissions with role-based access control. Assign Owner, Admin, Editor, or Viewer roles to enforce least-privilege access across your workspace."
 icon: "users"
 ---
 
@@ -11,11 +11,11 @@ Formo uses workspace roles to control what each teammate can view or change.
 - **Owner**: Full access to the workspace. Owners can invite admins, transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
 - **Admin**: Full access to the workspace. Can manage members, roles, and settings but cannot invite admin or delete the workspace and projects.
 - **Editor**: Can manage projects, forms, contracts, charts, dashboards, and alerts. Editors cannot manage members, workspace settings, and key project settings.
-- **Member**: Read-only access to projects and forms.
+- **Viewer**: Read-only access to projects and forms.
 
 ## User Roles and Permissions
 
-| Action | Owner | Admin | Editor | Member |
+| Action | Owner | Admin | Editor | Viewer |
 |--------|-------|-------|--------|--------|
 | **Workspace** | | | | |
 | View workspace members | ✅ | ✅ | ❌ | ❌ |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -11,7 +11,7 @@ Formo uses workspace roles to control what each teammate can view or change.
 - **Owner**: Full access to the workspace. Owners can invite admins, transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
 - **Admin**: Full access to the workspace. Can manage members, roles, and settings but cannot invite admin or delete the workspace and projects.
 - **Editor**: Can manage projects, forms, contracts, charts, dashboards, and alerts. Editors cannot manage members, workspace settings, and key project settings.
-- **Member**: Read-only access to projects and forms. Members cannot make changes.
+- **Member**: Read-only access to projects and forms.
 
 ## User Roles and Permissions
 
@@ -66,9 +66,3 @@ Formo uses workspace roles to control what each teammate can view or change.
 | View audit logs | ✅ | ✅ | ❌ | ❌ |
 | **Agent Memory (Ask AI)** | | | | |
 | Manage agent memory | ✅ | ✅ | ❌ | ❌ |
-
-<Note>
-Owners implicitly have every permission. Admins have all workspace- and
-project-management permissions **except** transferring ownership, deleting the
-workspace, and deleting projects.
-</Note>

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -23,12 +23,6 @@ icon: "users"
 | Update workspace tier | ✅ | ✅ | ❌ | ❌ |
 | Delete the workspace | ✅ | ❌ | ❌ | ❌ |
 | Transfer ownership to another member | ✅ | ❌ | ❌ | ❌ |
-| **Forms Management** | | | | |
-| View forms and responses | ✅ | ✅ | ✅ | ✅ |
-| Manage responses of forms | ✅ | ✅ | ✅ | ❌ |
-| Create and edit forms | ✅ | ✅ | ✅ | ❌ |
-| Archive forms | ✅ | ✅ | ✅ | ❌ |
-| Close forms | ✅ | ✅ | ✅ | ❌ |
 | **Projects** | | | | |
 | View projects | ✅ | ✅ | ✅ | ✅ |
 | Verify projects | ✅ | ✅ | ✅ | ✅ |
@@ -46,7 +40,7 @@ icon: "users"
 | Explorer (SQL editor and wallet search) | ✅ | ✅ | ✅ | ❌ |
 | Create, delete, edit charts | ✅ | ✅ | ✅ | ❌ |
 | Create dashboards | ✅ | ✅ | ✅ | ❌ |
-| **Users & Wallets** | | | | |
+| **Users** | | | | |
 | View wallet profiles | ✅ | ✅ | ✅ | ✅ |
 | Import wallet addresses | ✅ | ✅ | ✅ | ❌ |
 | Edit user profile properties and labels | ✅ | ✅ | ✅ | ❌ |
@@ -57,6 +51,12 @@ icon: "users"
 | **Alerts** | | | | |
 | View project alerts | ✅ | ✅ | ✅ | ✅ |
 | Create, delete, edit project alerts | ✅ | ✅ | ✅ | ❌ |
+| **Forms** | | | | |
+| View forms and responses | ✅ | ✅ | ✅ | ✅ |
+| Manage responses of forms | ✅ | ✅ | ✅ | ❌ |
+| Create and edit forms | ✅ | ✅ | ✅ | ❌ |
+| Archive forms | ✅ | ✅ | ✅ | ❌ |
+| Close forms | ✅ | ✅ | ✅ | ❌ |
 | **Data & Access** | | | | |
 | Manage API Keys | ✅ | ✅ | ❌ | ❌ |
 | MCP | ✅ | ✅ | ❌ | ❌ |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -36,22 +36,22 @@ Formo uses workspace roles to control what each teammate can view or change.
 | Manage project notifications | ✅ | ✅ | ❌ | ❌ |
 | Edit lifecycle thresholds | ✅ | ✅ | ❌ | ❌ |
 | Delete projects | ✅ | ❌ | ❌ | ❌ |
+| **Contracts** | | | | |
+| View project contracts | ✅ | ✅ | ✅ | ✅ |
+| Create, edit, delete project contracts | ✅ | ✅ | ✅ | ❌ |
+| Deploy/pause project pipeline | ✅ | ✅ | ❌ | ❌ |
 | **Segments** | | | | |
 | View project segments | ✅ | ✅ | ✅ | ✅ |
 | Create, delete, edit project segments | ✅ | ✅ | ✅ | ❌ |
 | **Charts, Dashboards & Explorer** | | | | |
 | View charts and dashboards | ✅ | ✅ | ✅ | ✅ |
-| Explorer (SQL editor and wallet search) | ✅ | ✅ | ✅ | ❌ |
 | Create, delete, edit charts | ✅ | ✅ | ✅ | ❌ |
 | Create dashboards | ✅ | ✅ | ✅ | ❌ |
+| Explorer (SQL editor and wallet search) | ✅ | ✅ | ✅ | ❌ |
 | **Users** | | | | |
 | View wallet profiles | ✅ | ✅ | ✅ | ✅ |
-| Import wallet addresses | ✅ | ✅ | ✅ | ❌ |
-| Edit user profile properties and labels | ✅ | ✅ | ✅ | ❌ |
-| **Contracts** | | | | |
-| View project contracts | ✅ | ✅ | ✅ | ✅ |
-| Create, edit, delete project contracts | ✅ | ✅ | ✅ | ❌ |
-| Deploy/pause project pipeline | ✅ | ✅ | ❌ | ❌ |
+| Import wallets | ✅ | ✅ | ✅ | ❌ |
+| Edit profile properties and labels | ✅ | ✅ | ✅ | ❌ |
 | **Alerts** | | | | |
 | View project alerts | ✅ | ✅ | ✅ | ✅ |
 | Create, delete, edit project alerts | ✅ | ✅ | ✅ | ❌ |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -39,7 +39,7 @@ Formo uses workspace roles to control what each teammate can view or change.
 | **Contracts** | | | | |
 | View project contracts | ✅ | ✅ | ✅ | ✅ |
 | Create, edit, delete project contracts | ✅ | ✅ | ✅ | ❌ |
-| Deploy/pause project pipeline | ✅ | ✅ | ❌ | ❌ |
+| Deploy contract events pipeline | ✅ | ✅ | ❌ | ❌ |
 | **Segments** | | | | |
 | View project segments | ✅ | ✅ | ✅ | ✅ |
 | Create, delete, edit project segments | ✅ | ✅ | ✅ | ❌ |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -8,7 +8,7 @@ icon: "users"
 
 - **Owner**: The creator of the team with full control over all aspects. Can transfer ownership and delete the team. Only one owner per team.
 - **Admin**: Help with managing the team. Can manage members, roles, workspace settings, and API keys / MCP, but cannot transfer ownership or delete the team.
-- **Editor**: Build and explore content. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL editor and wallet search), import wallets, edit user profile properties and labels, and manage agent memory. Can open project settings to manage contracts, alerts, and lifecycle, but cannot manage members or roles, cannot access workspace settings or API keys / MCP, and cannot create or delete projects.
+- **Editor**: Build and explore content. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL editor and wallet search), import wallets, and edit user profile properties and labels. Can open project settings to manage contracts and alerts, but cannot edit lifecycle thresholds or project integrations, cannot manage members, roles, workspace settings, API keys / MCP, or agent memory, and cannot create or delete projects.
 - **Member**: Read-only access to view content and analytics. Cannot use the Explorer, create dashboards, or edit user profile properties and labels, and cannot view the members list, workspace or project settings, agent memory, or API keys / MCP.
 
 ## User Roles and Permissions
@@ -33,8 +33,10 @@ icon: "users"
 | View projects | ✅ | ✅ | ✅ | ✅ |
 | Verify projects | ✅ | ✅ | ✅ | ✅ |
 | Access project settings page | ✅ | ✅ | ✅ | ❌ |
-| Create and edit project settings | ✅ | ✅ | ❌ | ❌ |
-| Edit lifecycle thresholds | ✅ | ✅ | ✅ | ❌ |
+| Create & rename projects | ✅ | ✅ | ❌ | ❌ |
+| Manage project integrations (Dune API key) | ✅ | ✅ | ❌ | ❌ |
+| Manage project notifications | ✅ | ✅ | ❌ | ❌ |
+| Edit lifecycle thresholds | ✅ | ✅ | ❌ | ❌ |
 | Delete projects | ✅ | ❌ | ❌ | ❌ |
 | **Segments** | | | | |
 | View project segments | ✅ | ✅ | ✅ | ✅ |
@@ -61,7 +63,7 @@ icon: "users"
 | Create BI auth tokens | ✅ | ✅ | ❌ | ❌ |
 | View audit logs | ✅ | ✅ | ❌ | ❌ |
 | **Agent Memory (Ask AI)** | | | | |
-| Manage agent memory | ✅ | ✅ | ✅ | ❌ |
+| Manage agent memory | ✅ | ✅ | ❌ | ❌ |
 
 <Note>
 Owners implicitly have every permission. Admins have all workspace- and

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -22,7 +22,7 @@ Formo uses workspace roles to control what each teammate can view or change.
 | Add, remove, and manage members | ✅ | ✅ | ❌ | ❌ |
 | Manage roles of members | ✅ | ✅ | ❌ | ❌ |
 | Access and manage workspace settings | ✅ | ✅ | ❌ | ❌ |
-| Update workspace tier | ✅ | ✅ | ❌ | ❌ |
+| Upgrade / downgrade workspace | ✅ | ✅ | ❌ | ❌ |
 | Delete the workspace | ✅ | ❌ | ❌ | ❌ |
 | Transfer ownership to another member | ✅ | ❌ | ❌ | ❌ |
 | **Projects** | | | | |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -8,7 +8,7 @@ icon: "users"
 
 - **Owner**: The creator of the team with full control over all aspects. Can transfer ownership and delete the team. Only one owner per team.
 - **Admin**: Help with managing the team. Can manage members, roles, workspace settings, and API keys / MCP, but cannot transfer ownership or delete the team.
-- **Editor**: Build and explore content. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL editor and wallet search), import wallets, and edit user profile properties and labels. Can open project settings to manage contracts and alerts, but cannot edit lifecycle thresholds or project integrations, cannot manage members, roles, workspace settings, API keys / MCP, or agent memory, and cannot create or delete projects.
+- **Editor**: Manage projects and forms. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL editor and wallet search), import wallets, and edit user profile properties and labels. Can open project settings to manage contracts and alerts, but cannot edit lifecycle thresholds or project integrations, cannot manage members, roles, workspace settings, API keys / MCP, or agent memory, and cannot create or delete projects.
 - **Member**: Read-only access to project and analytics. Cannot use the Explorer, create dashboards, or edit user profile properties and labels, and cannot view the members list, workspace or project settings, agent memory, or API keys / MCP.
 
 ## User Roles and Permissions

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -6,10 +6,12 @@ icon: "users"
 
 ## Overview
 
-- **Owner**: The creator of the team with full control over all aspects. Can transfer ownership and delete the team. Only one owner per team.
-- **Admin**: Help with managing the team. Can manage members, roles, workspace settings, and API keys / MCP, but cannot transfer ownership or delete the team.
-- **Editor**: Manage projects and forms. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL editor and wallet search), import wallets, and edit user profile properties and labels. Can open project settings to manage contracts and alerts, but cannot edit lifecycle thresholds or project integrations, cannot manage members, roles, workspace settings, API keys / MCP, or agent memory, and cannot create or delete projects.
-- **Member**: Read-only access to project and analytics. Cannot use the Explorer, create dashboards, or edit user profile properties and labels, and cannot view the members list, workspace or project settings, agent memory, or API keys / MCP.
+Formo uses workspace roles to control what each teammate can view or change.
+
+- **Owner**: Full access to the workspace. Owners can transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
+- **Admin**: Can manage the workspace, projects, forms, and analytics. Ownership transfer and destructive deletion remain owner-only.
+- **Editor**: Can manage day-to-day project content, including forms, contracts, charts, dashboards, and alerts. Editors cannot manage workspace settings or projects themselves.
+- **Member**: Read-only access to projects and analytics. Members cannot make changes.
 
 ## User Roles and Permissions
 

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -17,11 +17,13 @@ Formo uses workspace roles to control what each teammate can view or change.
 
 | Action | Owner | Admin | Editor | Member |
 |--------|-------|-------|--------|--------|
-| **Team Management** | | | | |
-| View workspace members list | ✅ | ✅ | ❌ | ❌ |
+| **Workspace** | | | | |
+| View workspace members | ✅ | ✅ | ❌ | ❌ |
 | Add, remove, and manage members | ✅ | ✅ | ❌ | ❌ |
 | Manage roles of members | ✅ | ✅ | ❌ | ❌ |
 | Access and manage workspace settings | ✅ | ✅ | ❌ | ❌ |
+| Manage billing | ✅ | ✅ | ❌ | ❌ |
+| View workspace usage | ✅ | ✅ | ❌ | ❌ |
 | Upgrade / downgrade workspace | ✅ | ✅ | ❌ | ❌ |
 | Delete the workspace | ✅ | ❌ | ❌ | ❌ |
 | Transfer ownership to another member | ✅ | ❌ | ❌ | ❌ |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -10,8 +10,8 @@ Formo uses workspace roles to control what each teammate can view or change.
 
 - **Owner**: Full access to the workspace. Owners can transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
 - **Admin**: Can manage the workspace, projects, and forms. Can manage members, roles, and settings but cannot transfer ownership or delete the team.
-- **Editor**: Can manage day-to-day project content, including forms, contracts, charts, dashboards, and alerts. Editors cannot manage workspace settings or projects themselves.
-- **Member**: Read-only access to projects and analytics. Members cannot make changes.
+- **Editor**: Can manage projects, forms, contracts, charts, dashboards, and alerts. Editors cannot manage workspace settings or projects themselves.
+- **Member**: Read-only access to projects and forms. Members cannot make changes.
 
 ## User Roles and Permissions
 

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -8,8 +8,8 @@ icon: "users"
 
 Formo uses workspace roles to control what each teammate can view or change.
 
-- **Owner**: Full access to the workspace. Owners can transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
-- **Admin**: Can manage the workspace, projects, and forms. Can manage members, roles, and settings but cannot transfer ownership or delete the team.
+- **Owner**: Full access to the workspace. Owners can invite admins, transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
+- **Admin**: Full access to the workspace. Can manage members, roles, and settings but cannot invite admin or delete the workspace and projects.
 - **Editor**: Can manage projects, forms, contracts, charts, dashboards, and alerts. Editors cannot manage members, workspace settings, and key project settings.
 - **Member**: Read-only access to projects and forms. Members cannot make changes.
 

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -7,18 +7,19 @@ icon: "users"
 ## Overview
 
 - **Owner**: The creator of the team with full control over all aspects. Can transfer ownership and delete the team. Only one owner per team.
-- **Admin**: Help with managing the team. Can manage members, roles, and settings but cannot transfer ownership or delete the team.
-- **Editor**: Manage forms and submissions. Can create and edit content but cannot manage team members or settings.
-- **Member**: View projects and forms. Read-only access to view content and analytics.
+- **Admin**: Help with managing the team. Can manage members, roles, workspace settings, and API keys / MCP, but cannot transfer ownership or delete the team.
+- **Editor**: Build and explore content. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL query editor and wallet search), import wallets, and edit user profile properties and labels. Can open project settings to manage contracts, alerts, and lifecycle, but cannot manage members or roles, cannot access workspace settings or API keys / MCP, and cannot create or delete projects.
+- **Member**: Read-only access to view content and analytics. Cannot use the Explorer, create dashboards, or edit user profile properties and labels, and cannot view the members list, workspace or project settings, or API keys / MCP.
 
 ## User Roles and Permissions
 
 | Action | Owner | Admin | Editor | Member |
 |--------|-------|-------|--------|--------|
 | **Team Management** | | | | |
+| View workspace members list | ✅ | ✅ | ❌ | ❌ |
 | Add, remove, and manage members | ✅ | ✅ | ❌ | ❌ |
 | Manage roles of members | ✅ | ✅ | ❌ | ❌ |
-| Manage workspace settings | ✅ | ✅ | ❌ | ❌ |
+| Access and manage workspace settings | ✅ | ✅ | ❌ | ❌ |
 | Update workspace tier | ✅ | ✅ | ❌ | ❌ |
 | Delete the workspace | ✅ | ❌ | ❌ | ❌ |
 | Transfer ownership to another member | ✅ | ❌ | ❌ | ❌ |
@@ -30,15 +31,19 @@ icon: "users"
 | Close forms | ✅ | ✅ | ✅ | ❌ |
 | **Projects** | | | | |
 | View projects | ✅ | ✅ | ✅ | ✅ |
-| Create and edit projects | ✅ | ✅ | ❌ | ❌ |
 | Verify projects | ✅ | ✅ | ✅ | ✅ |
+| Access project settings page | ✅ | ✅ | ✅ | ❌ |
+| Create and edit projects (name, allowed URLs) | ✅ | ✅ | ❌ | ❌ |
+| Edit lifecycle thresholds | ✅ | ✅ | ✅ | ❌ |
 | Delete projects | ✅ | ❌ | ❌ | ❌ |
 | **Segments** | | | | |
 | View project segments | ✅ | ✅ | ✅ | ✅ |
 | Create, delete, edit project segments | ✅ | ✅ | ✅ | ❌ |
-| **Charts** | | | | |
-| View charts | ✅ | ✅ | ✅ | ✅ |
+| **Charts, Dashboards & Explorer** | | | | |
+| View charts and dashboards | ✅ | ✅ | ✅ | ✅ |
+| Access the Explorer (SQL query editor and wallet search) | ✅ | ✅ | ✅ | ❌ |
 | Create, delete, edit charts | ✅ | ✅ | ✅ | ❌ |
+| Create dashboards | ✅ | ✅ | ✅ | ❌ |
 | **Contracts** | | | | |
 | View project contracts | ✅ | ✅ | ✅ | ✅ |
 | Create, edit, delete project contracts | ✅ | ✅ | ✅ | ❌ |
@@ -46,7 +51,14 @@ icon: "users"
 | **Alerts** | | | | |
 | View project alerts | ✅ | ✅ | ✅ | ✅ |
 | Create, delete, edit project alerts | ✅ | ✅ | ✅ | ❌ |
-| **Data Management** | | | | |
+| **Users & Wallets** | | | | |
+| View user and wallet profiles | ✅ | ✅ | ✅ | ✅ |
 | Import wallet addresses | ✅ | ✅ | ✅ | ❌ |
+| Edit user profile properties and labels | ✅ | ✅ | ✅ | ❌ |
+| **Data & Access** | | | | |
+| Access API keys / MCP | ✅ | ✅ | ❌ | ❌ |
 | Create BI auth tokens | ✅ | ✅ | ❌ | ❌ |
 | View audit logs | ✅ | ✅ | ❌ | ❌ |
+| **Agent Memory (Ask AI)** | | | | |
+| View agent memory | ✅ | ✅ | ✅ | ✅ |
+| Curate / manage agent memory | ✅ | ✅ | ✅ | ❌ |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -9,7 +9,7 @@ icon: "users"
 Formo uses workspace roles to control what each teammate can view or change.
 
 - **Owner**: Full access to the workspace. Owners can transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
-- **Admin**: Can manage the workspace, projects, forms, and analytics. Ownership transfer and destructive deletion remain owner-only.
+- **Admin**: Can manage the workspace, projects, and forms. Ownership transfer and destructive deletion remain owner-only.
 - **Editor**: Can manage day-to-day project content, including forms, contracts, charts, dashboards, and alerts. Editors cannot manage workspace settings or projects themselves.
 - **Member**: Read-only access to projects and analytics. Members cannot make changes.
 

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -34,7 +34,7 @@ icon: "users"
 | Verify projects | ✅ | ✅ | ✅ | ✅ |
 | Access project settings page | ✅ | ✅ | ✅ | ❌ |
 | Create & rename projects | ✅ | ✅ | ❌ | ❌ |
-| Manage project integrations (Dune API key) | ✅ | ✅ | ❌ | ❌ |
+| Manage project integrations (Dune SQL) | ✅ | ✅ | ❌ | ❌ |
 | Manage project notifications | ✅ | ✅ | ❌ | ❌ |
 | Edit lifecycle thresholds | ✅ | ✅ | ❌ | ❌ |
 | Delete projects | ✅ | ❌ | ❌ | ❌ |

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -9,7 +9,7 @@ icon: "users"
 Formo uses workspace roles to control what each teammate can view or change.
 
 - **Owner**: Full access to the workspace. Owners can invite admins, transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
-- **Admin**: Full access to the workspace. Can manage members, roles, and settings but cannot invite admin or delete the workspace and projects.
+- **Admin**: Full access to the workspace. Can manage members, roles, and settings but cannot invite admins or delete the workspace and projects.
 - **Editor**: Can manage projects, forms, contracts, charts, dashboards, and alerts. Editors cannot manage members, workspace settings, and key project settings.
 - **Viewer**: Read-only access to projects and forms.
 

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -9,7 +9,7 @@ icon: "users"
 - **Owner**: The creator of the team with full control over all aspects. Can transfer ownership and delete the team. Only one owner per team.
 - **Admin**: Help with managing the team. Can manage members, roles, workspace settings, and API keys / MCP, but cannot transfer ownership or delete the team.
 - **Editor**: Build and explore content. Can create and edit forms, segments, contracts, charts, dashboards, and alerts, use the Explorer (SQL editor and wallet search), import wallets, and edit user profile properties and labels. Can open project settings to manage contracts and alerts, but cannot edit lifecycle thresholds or project integrations, cannot manage members, roles, workspace settings, API keys / MCP, or agent memory, and cannot create or delete projects.
-- **Member**: Read-only access to view content and analytics. Cannot use the Explorer, create dashboards, or edit user profile properties and labels, and cannot view the members list, workspace or project settings, agent memory, or API keys / MCP.
+- **Member**: Read-only access to project and analytics. Cannot use the Explorer, create dashboards, or edit user profile properties and labels, and cannot view the members list, workspace or project settings, agent memory, or API keys / MCP.
 
 ## User Roles and Permissions
 

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -10,7 +10,7 @@ Formo uses workspace roles to control what each teammate can view or change.
 
 - **Owner**: Full access to the workspace. Owners can transfer ownership, delete the workspace, and delete projects. Each workspace has one owner.
 - **Admin**: Can manage the workspace, projects, and forms. Can manage members, roles, and settings but cannot transfer ownership or delete the team.
-- **Editor**: Can manage projects, forms, contracts, charts, dashboards, and alerts. Editors cannot manage workspace settings or projects themselves.
+- **Editor**: Can manage projects, forms, contracts, charts, dashboards, and alerts. Editors cannot manage members, workspace settings, and key project settings.
 - **Member**: Read-only access to projects and forms. Members cannot make changes.
 
 ## User Roles and Permissions

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -37,8 +37,8 @@ Formo uses workspace roles to control what each teammate can view or change.
 | Edit lifecycle thresholds | ✅ | ✅ | ❌ | ❌ |
 | Delete projects | ✅ | ❌ | ❌ | ❌ |
 | **Contracts** | | | | |
-| View project contracts | ✅ | ✅ | ✅ | ✅ |
-| Create, edit, delete project contracts | ✅ | ✅ | ✅ | ❌ |
+| View contracts | ✅ | ✅ | ✅ | ✅ |
+| Manage contracts | ✅ | ✅ | ✅ | ❌ |
 | Deploy contract events pipeline | ✅ | ✅ | ❌ | ❌ |
 | **Segments** | | | | |
 | View project segments | ✅ | ✅ | ✅ | ✅ |
@@ -57,7 +57,7 @@ Formo uses workspace roles to control what each teammate can view or change.
 | Create, delete, edit project alerts | ✅ | ✅ | ✅ | ❌ |
 | **Forms** | | | | |
 | View forms and responses | ✅ | ✅ | ✅ | ✅ |
-| Manage responses of forms | ✅ | ✅ | ✅ | ❌ |
+| Manage form responses | ✅ | ✅ | ✅ | ❌ |
 | Create and edit forms | ✅ | ✅ | ✅ | ❌ |
 | Archive forms | ✅ | ✅ | ✅ | ❌ |
 | Close forms | ✅ | ✅ | ✅ | ❌ |


### PR DESCRIPTION
Reconciles the RBAC role matrix in `security/roles.mdx` with the current product implementation (`TEAM_PERMISSIONS`), alongside getformo/formono#1999.

## Overview text
- Editor and Member descriptions rewritten to match the new gates.
- Fixed: admins **can** create projects (the old text implied otherwise).

## Matrix — new / changed rows
- **View workspace members list** — Owner/Admin only (was effectively visible to everyone).
- **Access and manage workspace settings** — Owner/Admin only.
- **Access API keys / MCP** — Owner/Admin only (new row).
- **Access project settings page** — hidden from Members; Editors keep it (they still manage contracts/alerts/lifecycle there).
- **Access the Explorer (SQL query editor and wallet search)** — blocked for Members (new row).
- **Create dashboards** — blocked for Members (new row; same permission as charts).
- **Edit user profile properties and labels** — blocked for Members (new row).

## Matrix — rows the docs were missing
- **Edit lifecycle thresholds** (Owner/Admin/Editor).
- **View agent memory** (all roles) and **Curate / manage agent memory** (Owner/Admin/Editor).

A couple of sections were regrouped for clarity (Explorer folded in with Charts & Dashboards; new "Users & Wallets" and "Data & Access" groupings). All ✅/❌ values were derived from `TEAM_PERMISSIONS` plus the UI-level gates shipped in the linked app PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKgfDzpRcpXdD7qmviggQE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKgfDzpRcpXdD7qmviggQE)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786246242&installation_id=130740768&pr_number=98&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F98&signature=441b8586c7d9d74d386c57ef41e0e909e02cf944d9cf0fdace163bb305bd279b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->