### PR TITLE
docs(alerts): fix inaccuracies against current implementation

### DIFF
--- a/api/alerts/create.mdx
+++ b/api/alerts/create.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Create Alert'
-description: 'Create a new alert for your project. Define trigger conditions on matching events or user-profile thresholds, and configure webhook notification delivery (including Slack).'
+description: 'Create a new alert for your project. Define trigger conditions and configure webhook notification delivery (including Slack).'
 openapi: 'POST /v0/alerts'
 ---

--- a/api/alerts/create.mdx
+++ b/api/alerts/create.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Create Alert'
-description: 'Create a new alert for your project. Define trigger conditions based on events or thresholds and configure notification delivery via webhooks or email.'
+description: 'Create a new alert for your project. Define trigger conditions on matching events or user-profile thresholds, and configure webhook notification delivery (including Slack).'
 openapi: 'POST /v0/alerts'
 ---

--- a/api/alerts/delete.mdx
+++ b/api/alerts/delete.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Delete Alert'
-description: 'Permanently delete an alert by ID. Removes the alert configuration, stops all notifications, and deletes the associated trigger history.'
+description: 'Permanently delete an alert by ID. Removes the alert configuration and stops all future notifications.'
 openapi: 'DELETE /v0/alerts/{alertId}'
 ---

--- a/api/alerts/get.mdx
+++ b/api/alerts/get.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Get Alert'
-description: 'Retrieve a single alert by ID. Returns the alert name, trigger conditions, notification channels, status, and recent alert history.'
+description: 'Retrieve a single alert by ID. Returns the alert name, trigger conditions, notification channel, and status.'
 openapi: 'GET /v0/alerts/{alertId}'
 ---

--- a/api/alerts/toggle.mdx
+++ b/api/alerts/toggle.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Toggle Alert'
-description: 'Enable or disable an alert by ID. Toggling an alert pauses or resumes notifications without deleting the alert configuration or history.'
+description: 'Enable or disable an alert by ID. Toggling an alert pauses or resumes notifications without deleting the alert configuration.'
 openapi: 'PATCH /v0/alerts/{alertId}'
 ---

--- a/api/alerts/update.mdx
+++ b/api/alerts/update.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Update Alert'
-description: 'Modify an existing alert by ID. Update the alert name, conditions, thresholds, and notification channel configuration through the Formo API.'
+description: 'Modify an existing alert by ID. Update the alert name, conditions, and webhook notification configuration through the Formo API.'
 openapi: 'PUT /v0/alerts/{alertId}'
 ---

--- a/api/idempotency.mdx
+++ b/api/idempotency.mdx
@@ -74,7 +74,7 @@ curl -X POST https://api.formo.so/v0/alerts \
     "trigger_filters": [
       { "name": "event", "operator": "equals", "value": "transaction" }
     ],
-    "recipient": [{ "type": "email", "value": ["alerts@myapp.com"] }]
+    "recipient": [{ "type": "webhook", "value": ["https://myapp.com/formo-webhook"] }]
   }'
 ```
 

--- a/api/overview.mdx
+++ b/api/overview.mdx
@@ -50,7 +50,7 @@ You can use the Profiles API for real-time personalization. Once you fetch a pro
 ## Alerts API
 
 - Create, update, and manage project alerts programmatically.
-- Configure alert conditions and notification channels (email, Slack, webhook).
+- Configure alert conditions and a webhook notification channel (including Slack, via a Slack incoming-webhook URL).
 
 ## Response shape
 

--- a/cli/alerts.mdx
+++ b/cli/alerts.mdx
@@ -5,7 +5,7 @@ icon: bell
 description: "Manage project alerts from the terminal with the Formo CLI. Create, list, update, test, delete, and toggle alerts that notify your team about matching events or users."
 ---
 
-The `formo alerts` command group manages project alerts. Alerts can notify email, Slack, or webhook recipients when event or user filters match.
+The `formo alerts` command group manages project alerts. Alerts notify a webhook (including Slack, via a Slack incoming-webhook URL) when event or user filters match.
 
 ## `formo alerts list`
 
@@ -63,11 +63,10 @@ Requires `alerts:write` scope on your API key.
 
 ### Recipient Shape
 
-`--recipient` is a JSON array. Each entry should include a `type` such as `email`, `slack`, or `webhook`, plus a `value`.
+`--recipient` is a JSON array. Only `type: "webhook"` is currently delivered to; use a `hooks.slack.com` URL as the `value` to post to Slack. `email`/`slack` type values are accepted by the schema but not delivered - use `webhook` instead.
 
 ```json
 [
-  { "type": "email", "value": ["team@example.com"] },
   { "type": "webhook", "value": ["https://example.com/formo-webhook"] }
 ]
 ```
@@ -81,13 +80,13 @@ formo alerts create \
   --name "Whale activity" \
   --trigger-type user \
   --trigger-filters '[{"name":"net_worth_usd","operator":"gt","value":100000}]' \
-  --recipient '[{"type":"email","value":["team@example.com"]}]'
+  --recipient '[{"type":"webhook","value":["https://example.com/formo-webhook"]}]'
 
 formo alerts create \
   --name "Slack revenue alert" \
-  --trigger-type event \
+  --trigger-type user \
   --trigger-filters '[{"name":"revenue","operator":"gt","numericThreshold":1000}]' \
-  --recipient '[{"type":"slack","value":["#alerts"]}]' \
+  --recipient '[{"type":"webhook","value":["https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"]}]' \
   --slack-property-keys '["event","revenue","address"]'
 ```
 
@@ -161,7 +160,7 @@ Requires `alerts:write` scope on your API key.
 ```bash
 formo alerts test alert_abc123 \
   --sample-event '{"event":"transaction","revenue":250}' \
-  --recipient-overrides '[{"type":"email","value":["team@example.com"]}]'
+  --recipient-overrides '[{"type":"webhook","value":["https://example.com/formo-webhook"]}]'
 ```
 
 <Note>

--- a/features/product-analytics/alerts.mdx
+++ b/features/product-analytics/alerts.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Alerts"
-description: "Set up real-time alerts for whale wallet connects, large transactions, and custom event thresholds with notifications delivered via webhook (including Slack via an incoming-webhook URL)."
+description: "Set up real-time alerts for high-value users, high-value transactions, and key user events, delivered via webhook or Slack."
 ---
 
 <Frame caption="Alerts">
@@ -37,13 +37,13 @@ Get real-time notifications when high-value users interact with your app. This g
 | Setting | Description |
 |---------|-------------|
 | **Name** | Descriptive name (e.g., "Whale Alert") |
-| **Trigger Type** | Event alerts (User alerts coming soon; see below) |
+| **Trigger Type** | Event or User (see below) |
 | **Conditions** | Filter conditions (optional) |
 | **Notification** | Webhook (generic HTTP or Slack via an incoming-webhook URL) |
 
 ### Step 3: Choose a trigger type
 
-Currently, **Event alerts** are the supported, working trigger type. **User alerts** are coming soon and the option is disabled in the dashboard.
+Formo supports two trigger types: **Event alerts**, which fire on individual matching events, and **User alerts**, which fire when a user profile matches your filters.
 
 <Tabs>
   <Tab title="Events">
@@ -56,11 +56,9 @@ Currently, **Event alerts** are the supported, working trigger type. **User aler
     | **page** | User visits a specific page |
     | **custom** | Your custom tracked events |
 
-    You can add conditions to filter on event properties (e.g., `chain_id = 8453`, `status = failed`).
+    You can add conditions to filter on the event's top-level fields: `type`, `event`, `address`, `user_id`, `anonymous_id`, `location`, `device`, `browser`, `os`, and `referrer`. Conditions support exact match, contains, starts with, ends with, and not-equals (e.g., `browser = Chrome`, `referrer contains twitter`). They can't filter on values nested in `properties` (like `chain_id` or a transaction's `status`) or use numeric comparisons (`>`, `<`) - use a User alert for numeric thresholds.
   </Tab>
-  <Tab title="Users (coming soon)">
-    <Note>User alerts are not yet available; the User trigger type is disabled in the dashboard. The behavior below describes the planned functionality.</Note>
-
+  <Tab title="Users">
     Triggers when a user profile matches your filters. Formo checks for matching users every 5 minutes and sends a notification for each new user that meets your criteria.
 
     Each matching user is **notified once per 24 hours** - if the same user remains active and continues to match, they won't be re-sent until the dedup window expires.
@@ -70,9 +68,9 @@ Currently, **Event alerts** are the supported, working trigger type. **User aler
     | Filter | Description |
     |--------|-------------|
     | **net_worth_usd** | Wallet net worth (e.g., > $100,000) |
-    | **tx_count** | Number of transactions |
     | **volume** | Trading volume |
     | **revenue** | Revenue generated |
+    | **points** | Loyalty points |
     | **location** | Country code |
     | **device** | Device type (desktop, mobile) |
     | **browser** | Browser name |
@@ -84,6 +82,8 @@ Currently, **Event alerts** are the supported, working trigger type. **User aler
     | **labels** | Wallet labels (e.g., Coinbase verified) |
     | **lifecycle** | User lifecycle stage (New, Returning, etc.) |
     | **socials** | Social profiles (e.g., Farcaster) |
+
+    `net_worth_usd`, `volume`, `revenue`, and `points` support numeric comparisons (`>`, `>=`, `<`, `<=`, `=`); the rest match on equality.
   </Tab>
 </Tabs>
 
@@ -317,9 +317,7 @@ Each message includes:
 
 ---
 
-### User alerts (coming soon)
-
-<Note>User alerts are not yet available; the User trigger type is disabled in the dashboard. The payload format below documents the planned behavior.</Note>
+### User alerts
 
 When a user alert is triggered, Formo sends matching user profiles to your webhook.
 
@@ -562,16 +560,14 @@ For Slack incoming webhooks, Formo formats user profiles as a rich card layout:
 
 ## Examples
 
-### Whale detection alert (coming soon)
-
-<Note>This example uses the **User** trigger type, which is not yet available. It's included to show the planned workflow.</Note>
+### Whale detection alert
 
 Notify when high-value users visit:
 
 | Setting | Value |
 |---------|-------|
 | Name | Whale Alert |
-| Trigger type | Users (coming soon) |
+| Trigger type | Users |
 | Condition | net_worth_usd > 100000 |
 | Notification | Slack webhook |
 
@@ -585,10 +581,10 @@ Track when users encounter issues:
 |---------|-------|
 | Name | Failed TX Alert |
 | Trigger type | Events |
-| Condition | type = transaction, status = failed |
+| Condition | type = transaction |
 | Notification | Webhook |
 
-Get notified when transactions fail so you can investigate UX issues.
+`status` lives in the event's `properties` object, not a filterable top-level field, so this condition sends every transaction event. Filter for `properties.status = "failed"` on your webhook receiver to isolate failures.
 
 ### Webhook integration examples
 

--- a/features/product-analytics/alerts.mdx
+++ b/features/product-analytics/alerts.mdx
@@ -56,7 +56,7 @@ Formo supports two trigger types: **Event alerts**, which fire on individual mat
     | **page** | User visits a specific page |
     | **custom** | Your custom tracked events |
 
-    You can add conditions to filter on the event's top-level fields: `type`, `event`, `address`, `user_id`, `anonymous_id`, `location`, `device`, `browser`, `os`, and `referrer`. Conditions support exact match, contains, starts with, ends with, and not-equals (e.g., `browser = Chrome`, `referrer contains twitter`). They can't filter on values nested in `properties` (like `chain_id` or a transaction's `status`) or use numeric comparisons (`>`, `<`) - use a User alert for numeric thresholds.
+    You can add conditions to filter on the event's top-level fields: `type`, `event`, `address`, `user_id`, `anonymous_id`, `location`, `device`, `browser`, `os`, and `referrer`. Conditions support exact match, contains, starts with, ends with, and not-equals (e.g., `browser = Chrome`, `referrer contains twitter`). They can't filter on values nested in `properties` (like `chain_id` or a transaction's `status`) or use numeric comparisons (`>`, `<`) - use a User alert if you need to filter on a number.
   </Tab>
   <Tab title="Users">
     Triggers when a user profile matches your filters. Formo checks for matching users every 5 minutes and sends a notification for each new user that meets your criteria.

--- a/features/wallet-intelligence/wallet-labels.mdx
+++ b/features/wallet-intelligence/wallet-labels.mdx
@@ -141,9 +141,9 @@ Turn useful label combinations into reusable segments:
 Set up alerts based on labels:
 
 1. Go to **Settings** > **Alerts**
-2. Create an alert for `connect` events
-3. Add condition: Lifecycle = "Power User" AND Net Worth > $100,000
-4. Get notified when high-value power users connect
+2. Create a **User** alert
+3. Add filters: Lifecycle = "Power User" AND net_worth_usd > 100000, or Labels = your target label
+4. Get notified within 5 minutes when a wallet matching those filters becomes active
 
 ### Next Steps
 

--- a/guides/contract-events.mdx
+++ b/guides/contract-events.mdx
@@ -174,7 +174,7 @@ Create alerts for important contract events:
 - "Alert me when a whale executes a swap"
 - "Alert me when a specific contract event fires"
 
-Alerts notify you in real time or on a daily digest, keeping you informed of important onchain activity.
+Alerts notify you in real time, keeping you informed of important onchain activity.
 
 ## Pipeline Management
 

--- a/guides/funnels.mdx
+++ b/guides/funnels.mdx
@@ -280,9 +280,9 @@ Track when transactions fail to identify UX issues that cause drop-off:
 
 1. Go to **Project Settings** > **Alerts**
 2. Click **Create Alert**
-3. Configure: Event = `transaction`, Condition = `status = failed`
+3. Configure: Trigger type = Events, Condition = `type = transaction`
 4. Set a destination to a webhook or Slack
-5. Investigate spikes in failures - they often correlate with funnel drop-off at the transaction step
+5. Filter the delivered events for `properties.status = "failed"` on your receiver (status isn't a filterable alert condition), and investigate spikes - they often correlate with funnel drop-off at the transaction step
 
 ## Next Steps
 

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -40,7 +40,7 @@ Query on-chain data from [Dune](https://dune.com) directly in your dashboards an
 
 ## Alerts & Notifications
 
-Formo delivers server-side alerts via webhook when events or user thresholds match your filters. Configure the recipient URL per alert.
+Formo delivers server-side alerts via webhook when an event matches your filters or a user profile crosses a threshold. Configure the recipient URL per alert.
 
 | Channel  | Supported | Details |
 |:---------|:----------|:--------|

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -40,7 +40,7 @@ Query on-chain data from [Dune](https://dune.com) directly in your dashboards an
 
 ## Alerts & Notifications
 
-Formo delivers server-side alerts via webhook when an event matches your filters or a user profile crosses a threshold. Configure the recipient URL per alert.
+Formo delivers server-side alerts via webhook when your filters match. Configure the recipient URL per alert.
 
 | Channel  | Supported | Details |
 |:---------|:----------|:--------|


### PR DESCRIPTION
Cross-checked against ../formono and fixed several claims that no longer match reality:

- User alerts shipped in March 2026 and are live in the dashboard; remove stale "coming soon"/disabled framing throughout.
- Event alert conditions only support equality/contains/startswith/ endswith/not-equals on a fixed field set (type, event, address, user_id, anonymous_id, location, device, browser, os, referrer) - no numeric thresholds, and no chain_id/status (those live in the properties JSON, not as filterable columns). Reword the top description and fix worked examples that used unsupported fields.
- Remove tx_count from User alert filters (UI-exposed but silently dropped server-side); add points, which is real.
- Alert recipients: only type "webhook" is ever delivered to; fix CLI/API examples that used "email" or "slack" recipient types.
- Remove fabricated "alert history" and "daily digest" claims - no such features exist in the backend.
- Fix a wallet-labels.mdx example that applied User-only filters (Lifecycle, Net Worth) to an Event alert.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786525242&installation_id=130740768&pr_number=99&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F99&signature=2fdca57d771e024f1331d07c0d8c06322bc85ced73b90aebe16a774495bcf080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->