### PR TITLE
docs: avoid 'engagement level' phrasing, list lifecycle stages explic…

### DIFF
--- a/features/wallet-intelligence/audience-insights.mdx
+++ b/features/wallet-intelligence/audience-insights.mdx
@@ -27,7 +27,7 @@ Apply filters to understand how different segments of users interact with your a
 
 ### Filter by Lifecycle
 
-Filter users by their [lifecycle stage](/features/wallet-intelligence/wallet-profiles#user-lifecycle) to create segments based on engagement level. Target new users, returning users, power users, resurrected users, at-risk users, or churned users.
+Filter users by their [lifecycle stage](/features/wallet-intelligence/wallet-profiles#user-lifecycle) to create segments: New, Power User, Resurrected, At Risk, Returning, Churned.
 
 ### Filter by Apps, Tokens, Chains
 

--- a/features/wallet-intelligence/segments.mdx
+++ b/features/wallet-intelligence/segments.mdx
@@ -30,7 +30,7 @@ You can use <a href="/features/wallet-intelligence/wallet-labels">wallet labels<
 
 ## User Lifecycle
 
-Each user's lifecycle stage is automatically calculated based on their activity. Filter users by lifecycle to create segments and audiences based on their engagement level.
+Each user's lifecycle stage is automatically calculated based on their activity. Filter users by lifecycle (New, Power User, Resurrected, At Risk, Returning, Churned) to create segments and audiences.
 
 See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for a breakdown of the different lifecycle stages.
 

--- a/guides/dau-tracking.mdx
+++ b/guides/dau-tracking.mdx
@@ -151,7 +151,7 @@ Formo classifies every wallet into one lifecycle stage (**New**, **Returning**, 
 
 View these segments by going to **Users** and applying the **Lifecycle** filter.
 
-### By engagement level
+### By activity level
 
 Create segments for different activity levels:
 


### PR DESCRIPTION
…itly

Replace vague "engagement level" references with the explicit lifecycle stages (New, Power User, Resurrected, At Risk, Returning, Churned) per the authoritative definition in wallet-profiles.mdx.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786528066&installation_id=130740768&pr_number=100&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F100&signature=51276c210fc6d8321a009db9921785b2e8031575f32ab22b1c2f908637d5181e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->