### PR TITLE
docs: fix outdated docs / inaccuracies against latest implementation

### DIFF
--- a/api/authentication.mdx
+++ b/api/authentication.mdx
@@ -44,15 +44,15 @@ When creating a Workspace API Key, select the scopes your key needs. Each API en
 | `mcp:read` | MCP protocol access | Scale / Enterprise |
 | `alerts:read` | List and get alerts | Scale / Enterprise |
 | `alerts:write` | Create, update, delete alerts (requires alerts:read) | Scale / Enterprise |
-| `boards:read` | List and get boards and charts | Growth / Scale / Enterprise |
-| `boards:write` | Create, update, delete boards and charts (requires boards:read) | Growth / Scale / Enterprise |
-| `contracts:read` | List contracts | Growth / Scale / Enterprise |
-| `contracts:write` | Create, update, delete contracts (requires contracts:read) | Growth / Scale / Enterprise |
-| `segments:read` | List segments | Growth / Scale / Enterprise |
-| `segments:write` | Create and delete segments (requires segments:read) | Growth / Scale / Enterprise |
+| `boards:read` | List and get boards and charts | Any plan |
+| `boards:write` | Create, update, delete boards and charts (requires boards:read) | Any plan |
+| `contracts:read` | List contracts | Any plan |
+| `contracts:write` | Create, update, delete contracts (requires contracts:read) | Any plan |
+| `segments:read` | List segments | Any plan |
+| `segments:write` | Create and delete segments (requires segments:read) | Any plan |
 
 <Note>
-  Write scopes automatically require the corresponding read scope. Profiles, Query, MCP, and Alerts scopes require a Scale or Enterprise plan; Boards, Contracts, and Segments scopes require Growth or above. Create keys with the required scopes in Team Settings &gt; API Keys.
+  Write scopes automatically require the corresponding read scope. Profiles, Query, MCP, and Alerts scopes require a Scale or Enterprise plan. Create keys with the required scopes in Team Settings &gt; API Keys.
 </Note>
 
 ## SDK Write Key

--- a/api/boards/create-chart.mdx
+++ b/api/boards/create-chart.mdx
@@ -6,7 +6,7 @@ openapi: "POST /v0/boards/{boardId}/charts"
 
 ## Overview
 
-Creates a new chart and attaches it to a board. Returns the new chart's ID on success.
+Creates a new chart and attaches it to a board. Returns the full chart object on success.
 
 The `chart_type` field controls which other request body fields are required or validated. Funnel charts are special - their SQL is **auto-generated** from the `steps` array, so pass `"SELECT 1"` as the `query` placeholder.
 
@@ -18,10 +18,10 @@ The `chart_type` field controls which other request body fields are required or 
 | ------------- | ------------- | ----------- | ----------------------------------------------------------------------------------------------- |
 | `projectId`   | string        | Yes         | Project the chart belongs to                                                                    |
 | `query`       | string        | Conditional | SQL query. Required for all types except `retention`. For `funnel`, pass `"SELECT 1"`           |
-| `chart_type`  | string        | Yes         | `table` · `number` · `bar` · `line` · `pie` · `stacked` · `funnel` · `user_paths` · `retention` |
+| `chart_type`  | string        | Yes         | `table` · `number` · `bar` · `line` · `area` · `pie` · `stacked` · `funnel` · `user_paths` · `retention` |
 | `title`       | string        | Yes         | Display name (minimum 1 character)                                                              |
 | `description` | string        | No          | Optional description                                                                            |
-| `x_axis`      | string        | Conditional | Column for the X axis. Required for `bar`, `line`, `stacked`                                    |
+| `x_axis`      | string        | Conditional | Column for the X axis. Required for `bar`, `line`, `area`, `stacked`                             |
 | `y_axis`      | string[]      | Conditional | Column(s) for Y axis metrics. See per-type rules below                                          |
 | `group_by`    | string        | Conditional | Column to group/stack series by. Required for `stacked`                                         |
 | `steps`       | FunnelStep[]  | Conditional | Ordered funnel steps. Required for `funnel` (minimum 2)                                         |
@@ -61,9 +61,9 @@ Renders a single scalar value (KPI card). The query **must** return exactly **1 
 
 ---
 
-### `bar` and `line`
+### `bar`, `line`, and `area`
 
-Both require `x_axis` and at least **1** column in `y_axis`.
+All three require `x_axis` and at least **1** column in `y_axis`. `area` requires exactly **1** column in `y_axis` when `group_by` is set.
 
 ```json
 {
@@ -165,7 +165,7 @@ Each step in the `steps` array has the following shape:
 | Field              | Type                   | Default    | Description                                                                                                    |
 | ------------------ | ---------------------- | ---------- | -------------------------------------------------------------------------------------------------------------- |
 | `funnelType`       | `"closed"` \| `"open"` | `"closed"` | `closed` - strict ordering, no events between steps; `open` - ordered but other events may occur between steps |
-| `conversionWindow` | `ConversionWindow`     | 1 day      | Max time from Step 1 for a user to complete all steps                                                          |
+| `conversionWindow` | `ConversionWindow`     | 2 days     | Max time from Step 1 for a user to complete all steps                                                          |
 | `breakdown`        | string                 | -          | Split each funnel bar by this dimension                                                                        |
 
 #### `ConversionWindow`
@@ -174,11 +174,11 @@ Each step in the `steps` array has the following shape:
 { "value": 7, "unit": "day" }
 ```
 
-`unit` must be one of: `minute` · `hour` · `day` · `week` (7 days) · `month` (30 days).
+`unit` must be one of: `hour` · `day` · `week` (7 days).
 
 #### `breakdown` values
 
-`device` · `browser` · `os` · `referrer` · `ref` · `utm_source` · `utm_medium` · `utm_campaign` · `utm_term` · `utm_content`
+`device` · `browser` · `os` · `location` · `referrer` · `ref` · `utm_source` · `utm_medium` · `utm_campaign` · `utm_term` · `utm_content` · `builder_codes`
 
 The top categories are shown individually. The rest collapse into **"Others"**.
 
@@ -295,8 +295,8 @@ Visualize how users navigate your app after a starting event. `settings.startSte
 | ------------------ | ---------------------- | ------- | ------------------------------------------------------------------ |
 | `startStep`        | `FunnelStep`           | -       | **Required.** Event where the flow begins                          |
 | `endStep`          | `FunnelStep` \| `null` | `null`  | Optional ending event. `null` = open-ended                         |
-| `maxSteps`         | integer (2–10)         | `3`     | Max steps to show in the flow. Values above 10 are clamped to 10   |
-| `nodesPerStep`     | integer (2–10)         | `5`     | Max unique event nodes per step. Values above 10 are clamped to 10 |
+| `maxSteps`         | integer (2 to 5)       | `3`     | Max steps to show in the flow. Values above 5 are clamped to 5     |
+| `nodesPerStep`     | integer (2 to 8)       | `5`     | Max unique event nodes per step. Values above 8 are clamped to 8   |
 | `conversionWindow` | `ConversionWindow`     | -       | Time window to group the flow                                      |
 | `filters`          | string                 | -       | JSON-encoded string of additional path filters                     |
 
@@ -383,13 +383,21 @@ For all-user retention with no filters, omit `settings`:
 
 ## Response
 
-**`201 Created`** - returns the new chart's ID as a bare JSON string.
+**`201 Created`** - returns the full chart object.
 
 ```json
-"chart_1a2b3c4d"
+{
+  "id": "chart_1a2b3c4d",
+  "chart_type": "table",
+  "title": "Recent Events",
+  "description": null,
+  "query": "SELECT * FROM events ORDER BY timestamp DESC LIMIT 10",
+  "project_id": "proj_abc",
+  "board_id": "board_xyz"
+}
 ```
 
-Use the returned ID with the [Get Chart](/api/boards/get-chart), [Update Chart](/api/boards/update-chart), and [Delete Chart](/api/boards/delete-chart) endpoints.
+Use the returned `id` with the [Get Chart](/api/boards/get-chart), [Update Chart](/api/boards/update-chart), and [Delete Chart](/api/boards/delete-chart) endpoints.
 
 **`400 Bad Request`** - validation failed (missing required fields, invalid SQL, wrong step count, etc.). Branch on `error.code`; see [Errors](/api/errors).
 
@@ -405,7 +413,7 @@ Use the returned ID with the [Get Chart](/api/boards/get-chart), [Update Chart](
 
 ## Overview
 
-Creates a new chart and attaches it to a board. Returns the new chart's ID on success.
+Creates a new chart and attaches it to a board. Returns the full chart object on success.
 
 The `chart_type` field controls which other request body fields are required or validated. Funnel charts are special - their SQL is **auto-generated** from the `steps` array, so pass `"SELECT 1"` as the `query` placeholder.
 
@@ -417,10 +425,10 @@ The `chart_type` field controls which other request body fields are required or 
 | ------------- | ------------- | ----------- | ----------------------------------------------------------------------------------------------- |
 | `projectId`   | string        | Yes         | Project the chart belongs to                                                                    |
 | `query`       | string        | Conditional | SQL query. Required for all types except `retention`. For `funnel`, pass `"SELECT 1"`           |
-| `chart_type`  | string        | Yes         | `table` · `number` · `bar` · `line` · `pie` · `stacked` · `funnel` · `user_paths` · `retention` |
+| `chart_type`  | string        | Yes         | `table` · `number` · `bar` · `line` · `area` · `pie` · `stacked` · `funnel` · `user_paths` · `retention` |
 | `title`       | string        | Yes         | Display name (minimum 1 character)                                                              |
 | `description` | string        | No          | Optional description                                                                            |
-| `x_axis`      | string        | Conditional | Column for the X axis. Required for `bar`, `line`, `stacked`                                    |
+| `x_axis`      | string        | Conditional | Column for the X axis. Required for `bar`, `line`, `area`, `stacked`                             |
 | `y_axis`      | string[]      | Conditional | Column(s) for Y axis metrics. See per-type rules below                                          |
 | `group_by`    | string        | Conditional | Column to group/stack series by. Required for `stacked`                                         |
 | `steps`       | FunnelStep[]  | Conditional | Ordered funnel steps. Required for `funnel` (minimum 2)                                         |
@@ -460,9 +468,9 @@ Renders a single scalar value (KPI card). The query **must** return exactly **1 
 
 ---
 
-### `bar` and `line`
+### `bar`, `line`, and `area`
 
-Both require `x_axis` and at least **1** column in `y_axis`.
+All three require `x_axis` and at least **1** column in `y_axis`. `area` requires exactly **1** column in `y_axis` when `group_by` is set.
 
 ```json
 {
@@ -564,7 +572,7 @@ Each step in the `steps` array has the following shape:
 | Field              | Type                   | Default    | Description                                                                                                    |
 | ------------------ | ---------------------- | ---------- | -------------------------------------------------------------------------------------------------------------- |
 | `funnelType`       | `"closed"` \| `"open"` | `"closed"` | `closed` - strict ordering, no events between steps; `open` - ordered but other events may occur between steps |
-| `conversionWindow` | `ConversionWindow`     | 1 day      | Max time from Step 1 for a user to complete all steps                                                          |
+| `conversionWindow` | `ConversionWindow`     | 2 days     | Max time from Step 1 for a user to complete all steps                                                          |
 | `breakdown`        | string                 | -          | Split each funnel bar by this dimension                                                                        |
 
 #### `ConversionWindow`
@@ -573,11 +581,11 @@ Each step in the `steps` array has the following shape:
 { "value": 7, "unit": "day" }
 ```
 
-`unit` must be one of: `minute` · `hour` · `day` · `week` (7 days) · `month` (30 days).
+`unit` must be one of: `hour` · `day` · `week` (7 days).
 
 #### `breakdown` values
 
-`device` · `browser` · `os` · `referrer` · `ref` · `utm_source` · `utm_medium` · `utm_campaign` · `utm_term` · `utm_content`
+`device` · `browser` · `os` · `location` · `referrer` · `ref` · `utm_source` · `utm_medium` · `utm_campaign` · `utm_term` · `utm_content` · `builder_codes`
 
 The top categories are shown individually. The rest collapse into **"Others"**.
 
@@ -694,8 +702,8 @@ Visualize how users navigate your app after a starting event. `settings.startSte
 | ------------------ | ---------------------- | ------- | ------------------------------------------------------------------ |
 | `startStep`        | `FunnelStep`           | -       | **Required.** Event where the flow begins                          |
 | `endStep`          | `FunnelStep` \| `null` | `null`  | Optional ending event. `null` = open-ended                         |
-| `maxSteps`         | integer (2–10)         | `3`     | Max steps to show in the flow. Values above 10 are clamped to 10   |
-| `nodesPerStep`     | integer (2–10)         | `5`     | Max unique event nodes per step. Values above 10 are clamped to 10 |
+| `maxSteps`         | integer (2 to 5)       | `3`     | Max steps to show in the flow. Values above 5 are clamped to 5     |
+| `nodesPerStep`     | integer (2 to 8)       | `5`     | Max unique event nodes per step. Values above 8 are clamped to 8   |
 | `conversionWindow` | `ConversionWindow`     | 2 weeks | Time window to group the flow                                      |
 | `filters`          | string                 | -       | JSON-encoded string of additional path filters                     |
 
@@ -782,13 +790,21 @@ For all-user retention with no filters, omit `settings`:
 
 ## Response
 
-**`201 Created`** - returns the new chart's ID as a bare JSON string.
+**`201 Created`** - returns the full chart object.
 
 ```json
-"chart_1a2b3c4d"
+{
+  "id": "chart_1a2b3c4d",
+  "chart_type": "table",
+  "title": "Recent Events",
+  "description": null,
+  "query": "SELECT * FROM events ORDER BY timestamp DESC LIMIT 10",
+  "project_id": "proj_abc",
+  "board_id": "board_xyz"
+}
 ```
 
-Use the returned ID with the [Get Chart](/api/boards/get-chart), [Update Chart](/api/boards/update-chart), and [Delete Chart](/api/boards/delete-chart) endpoints.
+Use the returned `id` with the [Get Chart](/api/boards/get-chart), [Update Chart](/api/boards/update-chart), and [Delete Chart](/api/boards/delete-chart) endpoints.
 
 **`400 Bad Request`** - validation failed (missing required fields, invalid SQL, wrong step count, etc.). Branch on `error.code`; see [Errors](/api/errors).
 

--- a/api/boards/get.mdx
+++ b/api/boards/get.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Get Board'
-description: 'Retrieve a single dashboard board by ID. Returns the board title, description, layout configuration, and associated chart metadata.'
+description: 'Retrieve a single dashboard board by ID. Returns the board title, description, and associated chart metadata.'
 openapi: 'GET /v0/boards/{boardId}'
 ---

--- a/api/boards/list.mdx
+++ b/api/boards/list.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'List Boards'
-description: 'Retrieve all dashboard boards for your project. Returns board IDs, titles, descriptions, and chart counts for each analytics dashboard.'
+description: 'Retrieve all dashboard boards for your project. Returns board IDs, titles, and descriptions for each analytics dashboard.'
 openapi: 'GET /v0/boards'
 ---

--- a/api/boards/update.mdx
+++ b/api/boards/update.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Update Board'
-description: 'Update a dashboard board by ID. Modify the board title, description, or layout configuration for your analytics dashboards via the Formo API.'
+description: 'Update a dashboard board by ID. Modify the board title or description for your analytics dashboards via the Formo API.'
 openapi: 'PATCH /v0/boards/{boardId}'
 ---

--- a/api/contracts/create.mdx
+++ b/api/contracts/create.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Add Contract'
-description: 'Register a new smart contract for event tracking by providing a chain ID, contract address, and optional ABI for automatic event decoding.'
+description: 'Register a new smart contract for event tracking by providing a chain ID, contract address, and an ABI for automatic event decoding.'
 openapi: 'POST /v0/contracts'
 ---

--- a/api/errors.mdx
+++ b/api/errors.mdx
@@ -29,6 +29,10 @@ Every non-2xx response from the Formo Public API uses the same envelope:
 
 The HTTP status code carries success/failure; **success bodies are never wrapped** - `GET /v0/alerts/alrt_…` returns the alert directly.
 
+<Note>
+The events-gateway service (`events.formo.so`, used by [Track Event](/api/events/track) and `/v0/raw_events`) is a separate service and does not use this envelope. It returns a simpler plain-string error shape, for example `{"error": "Unauthorized"}`, with no `code`, `message`, or `doc_url`.
+</Note>
+
 ## Handling errors well
 
 1. **Branch on `code`, not `message` or status alone.** Status families collide (most validation issues are `400 BAD_REQUEST`); the `code` enum disambiguates.

--- a/api/idempotency.mdx
+++ b/api/idempotency.mdx
@@ -5,7 +5,7 @@ icon: rotate
 iconType: solid
 ---
 
-Public unsafe methods (POST / PUT / PATCH / DELETE on `/v0/*`) honour an optional `Idempotency-Key` header. When present, Formo de-duplicates retries so a flaky network or a crashed client never causes a double-write.
+Public unsafe methods (POST / PUT / PATCH / DELETE) on the Alerts, Boards, Contracts, Segments, and Import APIs honour an optional `Idempotency-Key` header. When present, Formo de-duplicates retries so a flaky network or a crashed client never causes a double-write.
 
 The header is **opt-in** - omit it and every request is processed independently.
 

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4517,10 +4517,12 @@
                   "type": "object",
                   "properties": {
                     "status": { "type": "string", "enum": ["processing"] },
+                    "address": { "type": "string" },
+                    "message": { "type": "string" },
                     "retry_after": { "type": "integer", "description": "Seconds to wait before retrying." }
                   }
                 },
-                "example": { "status": "processing", "retry_after": 5 }
+                "example": { "status": "processing", "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "message": "Wallet profile is being generated. Retry shortly.", "retry_after": 3 }
               }
             }
           },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -327,7 +327,7 @@
       },
       "ConversionWindow": {
         "type": "object",
-        "description": "Time window within which a user must complete all funnel steps (measured from Step 1). Defaults to 1 day if omitted.",
+        "description": "Time window within which a user must complete all funnel steps (measured from Step 1). Defaults to 2 days if omitted.",
         "properties": {
           "value": {
             "type": "integer",
@@ -337,13 +337,11 @@
           "unit": {
             "type": "string",
             "enum": [
-              "minute",
               "hour",
               "day",
-              "week",
-              "month"
+              "week"
             ],
-            "description": "Time unit. `month` = 30 days, `week` = 7 days."
+            "description": "Time unit. `week` = 7 days."
           }
         },
         "required": [
@@ -499,13 +497,15 @@
               "device",
               "browser",
               "os",
+              "location",
               "referrer",
               "ref",
               "utm_source",
               "utm_medium",
               "utm_campaign",
               "utm_term",
-              "utm_content"
+              "utm_content",
+              "builder_codes"
             ],
             "description": "**Funnel only.** Split each funnel bar by this dimension. The top categories are shown individually; the rest are collapsed into 'Others'."
           },
@@ -527,16 +527,16 @@
           "maxSteps": {
             "type": "integer",
             "minimum": 2,
-            "maximum": 10,
+            "maximum": 5,
             "default": 3,
-            "description": "**user_paths.** Maximum number of steps to show in the flow (2 to 10). Values above 10 are clamped to 10."
+            "description": "**user_paths.** Maximum number of steps to show in the flow (2 to 5). Values above 5 are clamped to 5."
           },
           "nodesPerStep": {
             "type": "integer",
             "minimum": 2,
-            "maximum": 10,
+            "maximum": 8,
             "default": 5,
-            "description": "**user_paths.** Maximum number of unique event nodes visible per step (2 to 10). Values above 10 are clamped to 10."
+            "description": "**user_paths.** Maximum number of unique event nodes visible per step (2 to 8). Values above 8 are clamped to 8."
           },
           "filters": {
             "type": "string",
@@ -596,12 +596,13 @@
               "funnel",
               "bar",
               "line",
+              "area",
               "pie",
               "stacked",
               "user_paths",
               "retention"
             ],
-            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.startStep` |\n| `retention` | none (`query` ignored) |"
+            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.startStep` |\n| `retention` | none (`query` ignored) |"
           },
           "title": {
             "type": "string",
@@ -670,12 +671,13 @@
               "funnel",
               "bar",
               "line",
+              "area",
               "pie",
               "stacked",
               "user_paths",
               "retention"
             ],
-            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.startStep` |\n| `retention` | none (`query` ignored) |"
+            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.startStep` |\n| `retention` | none (`query` ignored) |"
           },
           "title": {
             "type": "string",
@@ -735,6 +737,7 @@
               "funnel",
               "bar",
               "line",
+              "area",
               "pie",
               "stacked",
               "user_paths",
@@ -1281,8 +1284,7 @@
           "type",
           "anonymous_id",
           "version",
-          "channel",
-          "message_id"
+          "channel"
         ],
         "properties": {
           "type": {
@@ -1351,7 +1353,7 @@
           },
           "message_id": {
             "type": "string",
-            "description": "Unique ID for deduplication"
+            "description": "Unique ID for deduplication. Optional; a UUID is generated server-side when omitted."
           }
         }
       },
@@ -1991,7 +1993,7 @@
       "AnalyticsBehaviorFilters": {
         "name": "behavior_filters",
         "in": "query",
-        "description": "JSON array filtering users by event-based behavior with counts and either an absolute date range or a window relative to the user's first event. Each entry is `{ event, op, count, date_from?, date_to?, event_type?, relative_to?, window? }`. When `relative_to: \"first_seen\"` is set, the matching events must occur within `window.value` `window.unit` (`hour` | `day`) after the user's first event; `date_from`/`date_to` are ignored. `event_type` narrows matching to a specific event-type column (`page`, `connect`, `disconnect`, `chain`, `signature`, `transaction`, `track`, `decoded_log`, `detect`, `identify`); for `track` and `decoded_log` the `event` field is the named identifier; for other types only the `type` column is matched.",
+        "description": "JSON array filtering users by event-based behavior with counts and either an absolute date range or a window relative to the user's first event. Each entry is `{ event, op, times, date_from?, date_to?, event_type?, relative_to?, window? }`. When `relative_to: \"first_seen\"` is set, the matching events must occur within `window.value` `window.unit` (`hour` | `day`) after the user's first event; `date_from`/`date_to` are ignored. `event_type` narrows matching to a specific event-type column (`page`, `connect`, `disconnect`, `chain`, `signature`, `transaction`, `track`, `decoded_log`, `detect`, `identify`); for `track` and `decoded_log` the `event` field is the named identifier; for other types only the `type` column is matched.",
         "content": {
           "application/json": {
             "schema": {
@@ -2005,7 +2007,7 @@
                 "event": "swap",
                 "event_type": "track",
                 "op": "greaterOrEqual",
-                "count": 1,
+                "times": 1,
                 "relative_to": "first_seen",
                 "window": { "value": 24, "unit": "hour" }
               }
@@ -3443,8 +3445,8 @@
                         "type": "event",
                         "event": "page"
                       },
-                      "maxSteps": 8,
-                      "nodesPerStep": 10
+                      "maxSteps": 5,
+                      "nodesPerStep": 8
                     }
                   }
                 },
@@ -4501,6 +4503,27 @@
               }
             }
           },
+          "202": {
+            "description": "Wallet not yet profiled. Returned for a first-time lookup while the profile is still being built; retry after the given delay.",
+            "headers": {
+              "Retry-After": {
+                "schema": { "type": "integer" },
+                "description": "Seconds to wait before retrying."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": { "type": "string", "enum": ["processing"] },
+                    "retry_after": { "type": "integer", "description": "Seconds to wait before retrying." }
+                  }
+                },
+                "example": { "status": "processing", "retry_after": 5 }
+              }
+            }
+          },
           "404": {
             "description": "Profile not found",
             "content": {
@@ -4731,8 +4754,7 @@
               "type": "string"
             },
             "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
-          },
-          { "$ref": "#/components/parameters/IdempotencyKey" }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -4954,8 +4976,7 @@
               "type": "string"
             },
             "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
-          },
-          { "$ref": "#/components/parameters/IdempotencyKey" }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -5061,8 +5082,7 @@
               "type": "string"
             },
             "description": "Wallet address. Accepts an EVM (0x...) or Solana address, or an ENS name (e.g. vitalik.eth) which is resolved to an address."
-          },
-          { "$ref": "#/components/parameters/IdempotencyKey" }
+          }
         ],
         "requestBody": {
           "required": true,

--- a/api/overview.mdx
+++ b/api/overview.mdx
@@ -96,7 +96,7 @@ List endpoints use a Stripe-style envelope only because they need pagination met
 
 ## Idempotency
 
-Pass an `Idempotency-Key` header on POST/PUT/PATCH/DELETE so retries can't double-create or double-charge. The first response is cached for 24 hours and replayed byte-for-byte on retry.
+Pass an `Idempotency-Key` header on POST/PUT/PATCH/DELETE requests to the Alerts, Boards, Contracts, Segments, and Import APIs so retries can't double-create or double-charge. The first response is cached for 24 hours and replayed byte-for-byte on retry.
 
 ```http
 POST /v0/alerts HTTP/1.1

--- a/api/profiles/get.mdx
+++ b/api/profiles/get.mdx
@@ -391,6 +391,8 @@ On a cold or first-time wallet lookup, the profile may not be built yet. In that
 ```json
 {
   "status": "processing",
+  "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+  "message": "Wallet profile is being generated. Retry shortly.",
   "retry_after": 3
 }
 ```

--- a/api/profiles/get.mdx
+++ b/api/profiles/get.mdx
@@ -381,5 +381,18 @@ Array of token holdings:
 | 400 | `BAD_REQUEST` | Invalid address or ENS name, or the ENS name could not be resolved |
 | 401 | `UNAUTHORIZED` | Missing or invalid API key |
 | 403 | `FORBIDDEN` | API key does not have `profiles:read` permission |
-| 404 | `PROFILE_NOT_FOUND` | Profile does not exist |
+| 404 | `NOT_FOUND` | Profile does not exist |
 | 500 | `INTERNAL_SERVER_ERROR` | Failed to fetch wallet profile data |
+
+### Still processing
+
+On a cold or first-time wallet lookup, the profile may not be built yet. In that case the endpoint returns `202 Accepted` instead of an error:
+
+```json
+{
+  "status": "processing",
+  "retry_after": 3
+}
+```
+
+A `Retry-After` header is also set to the same value (in seconds). This is a normal, common path for first-time wallet lookups: wait `retry_after` seconds and request the same endpoint again.

--- a/api/profiles/search.mdx
+++ b/api/profiles/search.mdx
@@ -591,7 +591,7 @@ curl -sS -X GET \
   -d '{
     "conditions": [
       { "field": "users.net_worth_usd", "op": "gt", "value": 10000 },
-      { "field": "users.ens", "op": "eq", "value": true },
+      { "field": "users.ens", "op": "eq", "value": "" },
       { "field": "chains.1.balance", "op": "gt", "value": 0 }
     ],
     "logic": "and"

--- a/api/query.mdx
+++ b/api/query.mdx
@@ -33,7 +33,7 @@ Authorization: Bearer <your_workspace_api_key>
 Limits:
 - Query must be a single `SELECT`/`WITH` statement (read-only).
 - No comments or multiple statements.
-- `LIMIT` is required and must be `<= 1000`.
+- `LIMIT` is optional (defaults to 100 rows if omitted) and must be `<= 1000000`.
 
 ## Response
 
@@ -69,7 +69,7 @@ This endpoint uses `limit`/`offset` (not `page`/`size`) because the client contr
 
 Branch on `error.code`; see [Errors](/api/errors) for the full reference.
 
-- `400 BAD_REQUEST`: missing query, invalid SQL, `LIMIT` over 1000, or missing project id.
+- `400 BAD_REQUEST`: missing query, invalid SQL, `LIMIT` over 1,000,000, or missing project id.
 - `401 UNAUTHORIZED`: missing/invalid authorization header or API key.
 - `403 FORBIDDEN`: API key lacks `query:read` scope.
 - `404 NOT_FOUND`: project or read token not found.

--- a/api/query/kpis.mdx
+++ b/api/query/kpis.mdx
@@ -4,6 +4,6 @@ description: "Time-series traffic KPIs (visitors, pageviews, bounce rate, sessio
 openapi: "GET /v0/kpis"
 ---
 
-Returns the same KPI series that powers the Formo dashboard's overview chart. Here `visitors` is the per-day session count (the overview's **Sessions** card), while `unique_users` (and `unique_users_current` / `unique_users_previous`) are unique anonymous visitors (the overview's **Visitors** card), returned only when `include_previous_period=true` and no `group_by` is set.
+Returns the same KPI series that powers the Formo dashboard's overview chart. Here `sessions` is the per-day session count (the overview's **Sessions** card), while `visitors` (and `visitors_current` / `visitors_previous`) are unique anonymous visitors (the overview's **Visitors** card), returned only when `include_previous_period=true` and no `group_by` is set.
 
 Use `group_by` to break results down by `referrer`, `location`, `device`, `browser`, `os`, or any UTM dimension. Set `include_previous_period=true` to also receive the equivalent prior window for week-over-week comparisons.

--- a/api/query/top-sources.mdx
+++ b/api/query/top-sources.mdx
@@ -4,4 +4,6 @@ description: "Top traffic sources by referrer or UTM dimension over the selected
 openapi: "GET /v0/top_sources"
 ---
 
-Returns the top traffic sources for the project. Pass `metric_column` to switch between `referrer`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, and `utm_content`. Defaults to `referrer`.
+Returns the top traffic sources for the project. Pass `metric_column` to switch between `referrer`, `referrer_url`, `ref`, `origin`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`, `device`, `browser`, `os`, and `channel`. Defaults to `referrer`.
+
+`channel` is a distinct option: instead of returning a raw dimension value, it classifies each session into a marketing acquisition channel (e.g. Organic Search, Paid Social, Direct, Referral) using Formo's channel classifier, so you can see top-level channel performance without building the grouping logic yourself.

--- a/api/segments/list.mdx
+++ b/api/segments/list.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'List Segments'
-description: 'Retrieve all audience segments for your project using the Formo API. Returns segment names, filter criteria, and creation timestamps.'
+description: 'Retrieve all audience segments for your project using the Formo API. Returns segment names and filter criteria.'
 openapi: 'GET /v0/segments'
 ---

--- a/chains/overview.mdx
+++ b/chains/overview.mdx
@@ -27,9 +27,9 @@ Formo supports builders on Ethereum and all major EVM chains.
 | Avalanche Fuji            | ✅    | ✖️        | ✖️        | ✅        |
 | Base Mainnet              | ✅    | ✅        | ✅        | ✅        |
 | Base Sepolia              | ✅    | ✖️        | ✅        | ✅        |
-| Blast Mainnet             | ✅    | ✅        | ✅        | ✅        |
+| Blast Mainnet             | ✅    | ✅        | ✖️        | ✅        |
 | Blast Sepolia             | ✅    | ✖️        | ✖️        | ✅        |
-| BOB                       | ✅    | ✅        | ✅        | ✅        |
+| BOB                       | ✅    | ✅        | ✖️        | ✖️        |
 | BOB Testnet               | ✅    | ✖️        | ✅        | ✅        |
 | BNB Smart Chain Mainnet   | ✅    | ✅        | ✅        | ✅        |
 | BNB Smart Chain Testnet   | ✅    | ✖️        | ✅        | ✅        |
@@ -57,11 +57,11 @@ Formo supports builders on Ethereum and all major EVM chains.
 | Mantle Sepolia            | ✅    | ✖️        | ✖️        | ✅        |
 | MegaETH Mainnet           | ✅    | ✅        | ✅        | ✅        |
 | MegaETH Testnet           | ✅    | ✖️        | ✅        | ✅        |
-| Mode Mainnet              | ✅    | ✅        | ✅        | ✅        |
+| Mode Mainnet              | ✅    | ✅        | ✖️        | ✅        |
 | Mode Testnet              | ✅    | ✖️        | ✅        | ✅        |
-| Monad Mainnet           | ✅    | ✅        | ✖️        | ✅        |
+| Monad Mainnet           | ✅    | ✅        | ✅        | ✅        |
 | Monad Testnet           | ✅    | ✖️        | ✅        | ✅        |
-| Morph                     | ✅    | ✅        | ✖️        | ✅        |
+| Morph                     | ✅    | ✅        | ✖️        | ✖️        |
 | Morph Testnet             | ✅    | ✖️        | ✖️        | ✅        |
 | Optimism Mainnet          | ✅    | ✅        | ✅        | ✅        |
 | Optimism Sepolia          | ✅    | ✖️        | ✅        | ✅        |

--- a/data/catalog.mdx
+++ b/data/catalog.mdx
@@ -101,6 +101,7 @@ The core event log. Contains all user interaction events - page views, custom ev
 | `volume` | Float32 | Transaction volume extracted from `properties.volume` at ingest. Values above 100M are zeroed as anomalies. Always query this flat column instead of `JSONExtractFloat(properties, 'volume')` |
 | `revenue` | Float32 | Revenue extracted from `properties.revenue` at ingest. Values above 100M are zeroed as anomalies. Always query this flat column instead of `JSONExtractFloat(properties, 'revenue')` |
 | `points` | Float32 | Points extracted from `properties.points` at ingest. Values above 100M are zeroed as anomalies. Always query this flat column instead of `JSONExtractFloat(properties, 'points')` |
+| `channel_type` | LowCardinality(String) | Marketing channel type derived from attribution data |
 
 **Example:**
 
@@ -163,7 +164,7 @@ This is an **aggregate table**. Most columns require `-Merge` functions. Always 
 | `activity_dates` | AggregateFunction(groupUniqArrayIf, Date, UInt8) | `groupUniqArrayIfMerge(activity_dates)` |
 
 **Lifecycle definitions** (based on `activity_dates`, computed against a reference date that defaults to today):
-- **New**: `first_seen` within the last 30 days
+- **New**: `first_seen` within the last 30 days and still active
 - **Power**: `first_seen` more than 30 days ago and 5+ unique active days in the last 30 days
 - **Resurrected**: `first_seen` more than 30 days ago and re-engaged within the last 30 days after a 30+ day gap
 - **At Risk**: `first_seen` more than 30 days ago, still active, but `last_seen` 14+ days ago with fewer than 5 active days in the last 30 days, no 30+ day gap, and 1+ active day in the prior window (days 30 to 60 ago)
@@ -202,7 +203,7 @@ Profiles for users who haven’t connected a wallet yet. Same structure as `user
 |--------|------|---------------|
 | `anonymous_id` | String | Direct access |
 
-All other columns are identical to the [users](#users) table, with `anonymous_id` replacing `address` as the primary key.
+All other columns are identical to the [users](#users) table, with `anonymous_id` replacing `address` as the primary key, except `activity_dates`. In `anonymous_users`, `activity_dates` is `AggregateFunction(groupUniqArray, Date)`, read with `groupUniqArrayMerge(activity_dates)`, not `groupUniqArrayIfMerge()` as in `users`.
 
 ### sessions
 
@@ -215,28 +216,28 @@ Aggregated session data with engagement metrics and attribution. Each row repres
 | `origin` | String | Direct access |
 | `session_id` | String | Direct access |
 | `date` | Date | Direct access |
-| `device` | SimpleAggregateFunction(any, String) | Direct access |
-| `browser` | SimpleAggregateFunction(any, String) | Direct access |
-| `os` | SimpleAggregateFunction(any, String) | Direct access |
-| `location` | SimpleAggregateFunction(any, String) | Direct access |
-| `referrer` | SimpleAggregateFunction(any, String) | Direct access |
-| `ref` | SimpleAggregateFunction(any, String) | Direct access |
-| `utm_medium` | SimpleAggregateFunction(any, String) | Direct access |
-| `utm_source` | SimpleAggregateFunction(any, String) | Direct access |
-| `utm_campaign` | SimpleAggregateFunction(any, String) | Direct access |
-| `utm_content` | SimpleAggregateFunction(any, String) | Direct access |
-| `utm_term` | SimpleAggregateFunction(any, String) | Direct access |
-| `gclid` | SimpleAggregateFunction(any, String) | Direct access |
-| `gad_source` | SimpleAggregateFunction(any, String) | Direct access |
-| `fbclid` | SimpleAggregateFunction(any, String) | Direct access |
-| `msclkid` | SimpleAggregateFunction(any, String) | Direct access |
-| `ttclid` | SimpleAggregateFunction(any, String) | Direct access |
-| `twclid` | SimpleAggregateFunction(any, String) | Direct access |
-| `li_fat_id` | SimpleAggregateFunction(any, String) | Direct access |
-| `rdt_cid` | SimpleAggregateFunction(any, String) | Direct access |
-| `first_hit` | SimpleAggregateFunction(min, DateTime) | Direct access |
-| `latest_hit` | SimpleAggregateFunction(max, DateTime) | Direct access |
+| `device` | AggregateFunction(argMin, LowCardinality(String), String) | `argMinMerge(device)` |
+| `browser` | AggregateFunction(argMin, LowCardinality(String), String) | `argMinMerge(browser)` |
+| `os` | AggregateFunction(argMin, LowCardinality(String), String) | `argMinMerge(os)` |
+| `location` | AggregateFunction(argMin, LowCardinality(String), String) | `argMinMerge(location)` |
+| `referrer` | AggregateFunction(argMin, String, String) | `argMinMerge(referrer)` |
+| `referrer_url` | AggregateFunction(argMin, String, String) | `argMinMerge(referrer_url)` |
+| `ref` | AggregateFunction(argMin, String, String) | `argMinMerge(ref)` |
+| `utm_medium` | AggregateFunction(argMin, String, String) | `argMinMerge(utm_medium)` |
+| `utm_source` | AggregateFunction(argMin, String, String) | `argMinMerge(utm_source)` |
+| `utm_campaign` | AggregateFunction(argMin, String, String) | `argMinMerge(utm_campaign)` |
+| `utm_content` | AggregateFunction(argMin, String, String) | `argMinMerge(utm_content)` |
+| `utm_term` | AggregateFunction(argMin, String, String) | `argMinMerge(utm_term)` |
+| `channel_type` | AggregateFunction(argMin, LowCardinality(String), String) | `argMinMerge(channel_type)` |
+| `paid_source` | AggregateFunction(argMin, String, String) | `argMinMerge(paid_source)` |
+| `click_id` | AggregateFunction(argMin, String, String) | `argMinMerge(click_id)` |
+| `first_hit` | SimpleAggregateFunction(min, DateTime) | `min(first_hit)` |
+| `latest_hit` | SimpleAggregateFunction(max, DateTime) | `max(latest_hit)` |
 | `hits` | AggregateFunction(count) | `countMerge(hits)` |
+
+<Note>
+`device`, `browser`, `os`, `location`, and the attribution columns (`referrer`, `referrer_url`, `ref`, `utm_*`, `channel_type`) are `argMin` states that resolve to the session's first-touch (entry) value. Read them with `argMinMerge(...)`, not by selecting the column directly. `paid_source` (acquiring ad network) and `click_id` (raw click ID) resolve independently at the first non-empty paid touch, so they can come from different events within the same session; don't assume `click_id` belongs to the `paid_source` network.
+</Note>
 
 **Example:**
 
@@ -305,11 +306,12 @@ Financial metrics with full attribution context. Tracks revenue, transaction vol
 | `rdt_cid` | String | Reddit Ads click ID |
 | `event` | String | Revenue-generating event name |
 | `rdns` | String | Wallet RDNS identifier |
-| `provider_name` | String | Wallet provider name |
+| `provider_name` | SimpleAggregateFunction(any, String) | Wallet provider name. `SimpleAggregateFunction` values don't need a `-Merge` function on read, so this still reads directly like a plain string (see [Working with Aggregate Tables](#working-with-aggregate-tables)) |
 | `chain_id` | String | Blockchain chain ID |
 | `volume` | Float32 | Transaction volume (capped at 1B) |
 | `revenue` | Float32 | Revenue value (capped at 1B) |
 | `points` | Float32 | Points value (capped at 1B) |
+| `channel_type` | LowCardinality(String) | Marketing channel type derived from attribution data |
 
 **Example:**
 
@@ -361,16 +363,16 @@ This is an **aggregate table** (`AggregatingMergeTree`). Each trait is stored as
 | Column | Type | Description |
 |--------|------|-------------|
 | `address` | String | Wallet address (primary key within your project) |
-| `user_id` | String | Your own external user identifier |
-| `display_name` | String | Display name |
-| `email` | String | Email address |
-| `farcaster`, `discord`, `twitter`, `telegram`, `instagram`, `github`, `linkedin`, `facebook`, `tiktok`, `youtube`, `reddit` | String | Social handles |
-| `website` | String | Website URL |
-| `ens`, `lens`, `basenames`, `linea` | String | Web3 name-service handles |
-| `avatar` | String | Avatar image URL |
-| `description` | String | Bio / description |
-| `location` | String | Location |
-| `updated_at` | DateTime | Last time any trait was updated |
+| `user_id` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Your own external user identifier |
+| `display_name` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Display name |
+| `email` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Email address |
+| `farcaster`, `discord`, `twitter`, `telegram`, `instagram`, `github`, `linkedin`, `facebook`, `tiktok`, `youtube`, `reddit` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Social handles |
+| `website` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Website URL |
+| `ens`, `lens`, `basenames`, `linea` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Web3 name-service handles |
+| `avatar` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Avatar image URL |
+| `description` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Bio / description |
+| `location` | AggregateFunction(argMaxIf, String, DateTime, UInt8) | Location |
+| `updated_at` | SimpleAggregateFunction(max, DateTime) | Last time any trait was updated. Read with `max(updated_at)` |
 
 **Example:**
 
@@ -744,7 +746,11 @@ ORDER BY total_revenue DESC
 
 ```sql
 SELECT location, COUNT(*) AS session_count
-FROM sessions
+FROM (
+    SELECT session_id, argMinMerge(location) AS location
+    FROM sessions
+    GROUP BY session_id
+)
 GROUP BY location
 ORDER BY session_count DESC
 LIMIT 20
@@ -753,15 +759,23 @@ LIMIT 20
 ### Sessions by device and browser
 
 ```sql
-WITH top_browsers AS (
-    SELECT browser
+WITH session_attrs AS (
+    SELECT
+        session_id,
+        argMinMerge(device) AS device,
+        argMinMerge(browser) AS browser
     FROM sessions
+    GROUP BY session_id
+),
+top_browsers AS (
+    SELECT browser
+    FROM session_attrs
     GROUP BY browser
     ORDER BY COUNT(*) DESC
     LIMIT 10
 )
 SELECT device, browser, COUNT(*) AS session_count
-FROM sessions
+FROM session_attrs
 WHERE browser IN (SELECT browser FROM top_browsers)
 GROUP BY device, browser
 ORDER BY session_count DESC

--- a/data/events/common.mdx
+++ b/data/events/common.mdx
@@ -13,7 +13,7 @@ This guide covers the common and contextual fields in detail.
 | Name | Datatype | Required | Description |
 |:-----|:----------|:---------|:------------|
 | `type` | String | ✓ | Captures the type of event. Values can be either identify, track, connect, signature, transaction, and others. |
-| `channel` | String | ✓ | Identifies the source of the event. The Formo SDKs emit `web`, `mobile`, `server`, or `source`. Other values such as `onchain`, `import`, and `api` are reserved for platform and import-pipeline ingestion, not SDK-emitted events. |
+| `channel` | String | ✓ | Identifies the source of the event. The Formo SDKs emit `web`, `mobile`, or `server`. Other values such as `onchain`, `import`, and `api` are reserved for platform and import-pipeline ingestion, not SDK-emitted events. |
 | `version` | String | ✓ | Version of the event spec. |
 | `project_id` | String | ✓ | Unique identification for the project in the database. |
 | `session_id` | String | ✓ | Privacy-friendly daily changing session identifier. |

--- a/data/events/connect.mdx
+++ b/data/events/connect.mdx
@@ -11,6 +11,7 @@ It includes the newly connected chain ID and wallet address of the user.
 | Property | Type | Description |
 |:---------|:-----|:------------|
 | `chain_id` | Number | Chain ID of the network the wallet connected to. |
+| `provider_name` | String | Wallet connector/provider name (present when auto-captured through the wagmi integration). |
 
 ## Sample Payload
 

--- a/data/events/page.mdx
+++ b/data/events/page.mdx
@@ -39,7 +39,7 @@ On web, any non-UTM query-string parameters are also added as individual propert
 | `context.screen_density` | `window.devicePixelRatio` | `Dimensions.get("screen").scale` |
 | `context.viewport_width` | `window.innerWidth` | Not set |
 | `context.viewport_height` | `window.innerHeight` | Not set |
-| `context.os_name` | Not set | `iOS` or `Android` |
+| `context.os_name` | Not set | `ios` or `android` |
 | `context.os_version` | Not set | OS version string |
 | `context.device_model` | Not set | Device model (e.g., `iPhone 14 Pro`) |
 | `context.device_manufacturer` | Not set | Device manufacturer (e.g., `Apple`) |
@@ -113,7 +113,7 @@ Screen events from the [mobile SDK](/sdks/mobile) are sent as `page` events with
         "locale": "en-US",
         "timezone": "America/New_York",
         "location": "US",
-        "os_name": "iOS",
+        "os_name": "ios",
         "os_version": "17.0",
         "device_model": "iPhone 14 Pro",
         "device_manufacturer": "Apple",

--- a/data/metrics.mdx
+++ b/data/metrics.mdx
@@ -94,8 +94,9 @@ The acquisition channel that brought a session to your app. Every session is ass
 | 2 | Paid Video | Paid signal + referrer is a video platform (YouTube, Vimeo, Twitch, Dailymotion, Loom, Wistia) |
 | 3 | Paid Social | Paid signal + referrer is a social platform (Meta, X, LinkedIn, Reddit, TikTok, Pinterest, Snapchat, Threads, Discord, Telegram, Farcaster, ...) |
 | 4 | Email | `utm_medium` ∈ \{`email`, `e-mail`, `e_mail`, `newsletter`\}, or referrer is a known email or newsletter domain (Gmail, Proton Mail, Yahoo Mail, Outlook, Substack, Beehiiv, Paragraph) |
-| 5 | Referrals | `utm_medium=affiliate` or non-empty `ref` query parameter |
-| 6 | Display | `utm_medium` ∈ \{`display`, `banner`, `expandable`, `interstitial`\} |
+| 5a | Display (network match) | Referrer domain or `utm_source` matches a known ad-network domain (checked before Referrals, so network-matched traffic is never misclassified as a referral) |
+| 5b | Referrals | `utm_medium` ∈ \{`affiliate`, `referral`\} or non-empty `ref` query parameter |
+| 6 | Display (medium match) | `utm_medium` ∈ \{`display`, `banner`, `expandable`, `interstitial`\} (checked after Referrals) |
 | 7 | Paid Other | Paid signal that matched none of the above: a paid `utm_medium` or click ID with no recognized source or ad format. A catch-all so paid traffic is never relabelled as organic or Direct. |
 | 8 | AI | Referrer is an AI assistant domain (ChatGPT, Claude, Gemini, Copilot, Perplexity, DeepSeek, Phind, Poe, Mistral Chat, Meta AI, You.com, Pi, Grok, Qwen, Kimi, Hugging Face, Genspark) |
 | 9 | Organic Search | `utm_medium=organic` or referrer is a search engine with no paid signal |
@@ -120,7 +121,7 @@ How many users are using a particular device such as desktop, mobile, tablet, et
 
 ### Browsers
 
-Browser is the statistics of the browser used by the visitor. It is extracted from the User-Agent and Client Hints HTTP headers.
+Browser is the statistics of the browser used by the visitor. It is extracted from the User-Agent header.
 
 ### OS
 
@@ -136,7 +137,7 @@ The most recent date and time when a user or wallet was observed interacting wit
 
 ### User lifecycle
 
-The lifecycle stage of each wallet or visitor (New, Returning, Power User, Resurrected, At Risk, or Churned), computed from their activity recency and frequency relative to a reference date.
+The lifecycle stage of each wallet or visitor (New, Returning, Power user, Resurrected, At Risk, or Churned), computed from their activity recency and frequency relative to a reference date.
 
 See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds for each stage.
 

--- a/data/what-we-collect.mdx
+++ b/data/what-we-collect.mdx
@@ -183,9 +183,11 @@ They are added to a URL to track where a visitor came from.
 
 We track these UTM codes and assign it to each user:
 
-- `referral`
 - `ref`
+- `referral`
 - `refcode`
+- `af`
+- `referrer`
 
 ### Wallet Provider
 
@@ -215,7 +217,7 @@ We collect the wallet connected status to identify if a visitor has connected th
 
 > We collect and store signature and transaction metadata.
 
-We collect signature and transaction metadata such as statuses (success, failed, pending, etc.) and transaction hashes.
+We collect signature and transaction metadata such as statuses (confirmed, reverted, rejected, etc.) and transaction hashes.
 
 ### Form Data
 

--- a/features/product-analytics/activity.mdx
+++ b/features/product-analytics/activity.mdx
@@ -49,9 +49,12 @@ Each event has a structured schema and type based on the [event specs](/data/eve
 | `page` | Page view with URL path |
 | `connect` | Wallet connection |
 | `disconnect` | Wallet disconnection |
+| `chain` | Chain switches |
 | `signature` | Message signing |
 | `transaction` | Onchain transaction |
 | `track` | Custom events |
+| `identify` | User identification |
+| `detect` | Wallet provider detection |
 | `decoded_log` | Smart contract events |
 
 Click any event to expand and see all properties.
@@ -77,7 +80,7 @@ Use filters to narrow down the feed:
 | Connects from Twitter | type = connect, referrer contains twitter |
 | Visitors from marketing campaign | utm_source = newsletter |
 | Events from mobile devices | device = mobile |
-| Failed transactions | type = transaction, status = failed |
+| Failed transactions | type = transaction, status = reverted |
 | Wallet connects from Twitter | type = connect, referrer contains twitter |
 | Specific user's activity | address = 0x... |
 | Events on a specific page | path = /swap |
@@ -118,7 +121,7 @@ When users report problems, use the Activity Feed to investigate:
 **Investigating a failed transaction:**
 
 <Steps>
-  <Step title="Filter by type = transaction and status = failed" />
+  <Step title="Filter by type = transaction and status = reverted" />
   <Step title="Find the user's transaction" />
   <Step title="Click to expand and see error details" />
   <Step title="Check the preceding events for context" />
@@ -161,7 +164,7 @@ When users report problems, use the Activity Feed to investigate:
 **"Which transactions are failing?"**
 
 <Steps>
-  <Step title="Filter: type = transaction, status = failed" />
+  <Step title="Filter: type = transaction, status = reverted" />
   <Step title="Group by error message or contract" />
   <Step title="Identify the most common failure reasons" />
   <Step title="Check if failures correlate with specific flows" />

--- a/features/product-analytics/contract-events.mdx
+++ b/features/product-analytics/contract-events.mdx
@@ -5,6 +5,10 @@ description: 'Add smart contract addresses to ingest and decode onchain events l
 
 Add your contract address to start ingesting contract events.
 
+<Note>
+  Contract events require a paid plan. On the free plan, event selection is disabled with a "Contract events are only available on paid plans" message and an upgrade link.
+</Note>
+
 <Frame caption="Formo makes decoding onchain activity easy.">
 	<img src="/images/product-analytics-contract-events.png" alt="Product Analytics Contract Events" />
 </Frame>
@@ -42,7 +46,7 @@ Monitor your smart contract activity in real-time. This guide walks you through 
 | **Name** (optional) | Friendly name for reference | "Swap Router" |
 | **ABI** (optional) | Formo automatically fetches the contract ABI from Etherscan to decode events. |  |
 
-3. Click **Save**
+3. Click **Add contract**
 
 <Frame caption="Adding a contract to your project.">
 	<img src="/images/contract-events.png" alt="Adding a Contract and selecting Contract Events" />
@@ -56,8 +60,9 @@ Monitor your smart contract activity in real-time. This guide walks you through 
 After adding a contract, select one or more events to ingest into Formo:
 
 1. Click on your contract in the list
-2. You'll see all available events from the ABI
-3. Toggle on the events you want to track from the list
+2. Switch on the **Ingest contract events** toggle
+3. You'll see all available events from the ABI
+4. Toggle on the events you want to track from the list
 
 ### Step 4: View events in Activity Feed
 
@@ -93,7 +98,7 @@ Track user journey from landing page to completed swap:
 
 ### Supported chains
 
-Contract events is available on [40+ chains](/chains/overview) including all major EVM chains.
+Contract events is available on [31 chains](/chains/overview).
 
 ### Next Steps
 

--- a/features/product-analytics/contract-events.mdx
+++ b/features/product-analytics/contract-events.mdx
@@ -5,10 +5,6 @@ description: 'Add smart contract addresses to ingest and decode onchain events l
 
 Add your contract address to start ingesting contract events.
 
-<Note>
-  Contract events require a paid plan. On the free plan, event selection is disabled with a "Contract events are only available on paid plans" message and an upgrade link.
-</Note>
-
 <Frame caption="Formo makes decoding onchain activity easy.">
 	<img src="/images/product-analytics-contract-events.png" alt="Product Analytics Contract Events" />
 </Frame>

--- a/features/product-analytics/custom-events.mdx
+++ b/features/product-analytics/custom-events.mdx
@@ -33,10 +33,10 @@ Track actions that aren't captured automatically:
 <Tabs>
   <Tab title="Wagmi / React">
     ```tsx
-    import { useFormoAnalytics } from '@formo/analytics';
+    import { useFormo } from '@formo/analytics';
 
     function YourComponent() {
-      const analytics = useFormoAnalytics();
+      const analytics = useFormo();
 
       // Now you can track events
     }

--- a/features/product-analytics/explore.mdx
+++ b/features/product-analytics/explore.mdx
@@ -76,7 +76,7 @@ See the [Data Catalog](/data/catalog) for full column definitions, query pattern
 
 ## Best practices
 
-- Use `LIMIT` to control result size. Default is 1,000 rows; maximum is 1,000,000 rows
+- Use `LIMIT` to control result size. Default is 100 rows; maximum is 1,000,000 rows
 - Use date filters to improve query performance
 - Reference the [Event Spec](/data/events/overview) for available event properties
 - Use **Ask AI** to help write and fix queries

--- a/features/product-analytics/flows.mdx
+++ b/features/product-analytics/flows.mdx
@@ -52,12 +52,17 @@ Flows can start from any event. Select what you want to analyze:
 
 ### Step 3: Configure the flow
 
-1. Select **Starting event** (e.g., `connect`)
-2. Choose **Direction**:
-   - **Forward**: What happens after this event
-   - **Backward**: What led to this event
-3. Set **Number of steps** (typically 3-5)
-4. Click **Generate**
+Flows are configured as a positional step list rather than a direction toggle. Each row's role is determined by its position:
+
+- **Start**: The first row is your starting event (e.g., `connect`)
+- **Anchor**: Middle rows are the events users pass through next
+- **End**: The last row is where the flow ends
+
+1. Add rows for each step you want to trace, in order
+2. Set **Number of steps** (typically 3-5)
+3. Click **Generate**
+
+Flows always trace forward from the starting event; there is no backward-tracing option.
 
 ### Step 4: Read the flow chart
 
@@ -93,7 +98,6 @@ Look for these insights:
 Analyze what users do after connecting their wallet:
 
 | Starting event | `connect` |
-| Direction | Forward |
 | Steps | 4 |
 
 **Typical findings:**
@@ -104,10 +108,10 @@ Analyze what users do after connecting their wallet:
 
 ### Example: Path to conversion
 
-See how users reach a conversion event:
+See what users do leading up to a conversion event by setting your conversion event as the last (End) step in the list, with earlier steps left open to discover common precursor actions:
 
-| Starting event | Your conversion event (e.g., `Swap`) |
-| Direction | Backward |
+| Starting event | A page view or wallet event that typically precedes conversion |
+| End event | Your conversion event (e.g., `Swap`) |
 | Steps | 3 |
 
 **Questions to answer:**

--- a/features/product-analytics/funnels.mdx
+++ b/features/product-analytics/funnels.mdx
@@ -19,7 +19,7 @@ Visualize how users progress through a series of steps with Funnel Analysis.
 
 Specify a conversion window for your funnels to control the time period during which funnel steps must be completed.
 
-The default conversion window is 2 weeks, meaning all steps must be completed within that time. Longer windows will include more event completions.
+The default conversion window is 2 days, meaning all steps must be completed within that time. Longer windows will include more event completions.
 
 ## Step Order
 
@@ -44,7 +44,7 @@ Consider making the funnel less strict by removing some intermediate steps, or u
 
 Counts users who performed each event, regardless of sequence or timing.
 
-In this mode, users must complete all defined steps within the conversion window, but the order does not matter. The first step in your funnel could be the last action the user takes. This is useful when your funnel steps represent a set of actions rather than a linear journey.
+In this mode, users must complete all defined steps, but the order does not matter and the conversion window does not apply. Steps are matched across your full selected date range with no time constraint between them. The first step in your funnel could be the last action the user takes. This is useful when your funnel steps represent a set of actions rather than a linear journey.
 
 **When to use each mode:**
 
@@ -164,16 +164,9 @@ For each step, specify:
 
 ### Step 4: Set the conversion window
 
-Choose how long users have to complete all steps:
+Choose how long users have to complete all steps by entering a numeric value and selecting a unit (Hour, Day, or Week). The default is 2 days.
 
-| Window | Best for |
-|--------|----------|
-| 1 day | Immediate actions (mints, swaps) |
-| 7 days | Considered purchases |
-| 14 days (default) | Complex user journeys |
-| 30 days | Long sales cycles |
-
-Users must complete all steps within this window to count as converted.
+Users must complete all steps within this window to count as converted. Note that the conversion window only applies to Sequential (Closed) funnels; [Any Order (Open) funnels](#any-order-open-funnel) have no time constraint between steps.
 
 ### Step 5: Analyze your funnel
 

--- a/features/product-analytics/insights.mdx
+++ b/features/product-analytics/insights.mdx
@@ -9,8 +9,6 @@ Track how user behavior evolves over time across different dimensions with AI-po
   <img src="/images/insights.png" alt="Insights page showing acquisition quality, revenue, and churn prediction" />
 </Frame>
 
-<Note>Insights isn't available during your trial period; trial workspaces see an upgrade prompt instead of the Insights page.</Note>
-
 ## Cohort Analysis
 
 Insights runs a cohort analysis that answers three key questions about your users:

--- a/features/product-analytics/insights.mdx
+++ b/features/product-analytics/insights.mdx
@@ -1,46 +1,36 @@
 ---
 title: 'Insights'
-description: 'Receive AI-powered weekly insights that surface acquisition quality, activation moments, revenue trends, and churn signals from your analytics data.'
+description: 'Receive AI-powered insights that surface acquisition quality, revenue trends, and churn signals from your analytics data.'
 ---
 
-Track how user behavior evolves over time across different dimensions with AI-powered cohort analysis. Insights automatically analyzes your data each week and surfaces actionable findings across acquisition, activation, revenue, and churn.
+Track how user behavior evolves over time across different dimensions with AI-powered cohort analysis. Insights refreshes when you open the page and surfaces actionable findings across acquisition, revenue, and churn.
 
-<Frame caption="Insights surfaces weekly cohort analysis across four key dimensions.">
-  <img src="/images/insights.png" alt="Insights page showing acquisition quality, activation, revenue, and churn prediction" />
+<Frame caption="Insights surfaces cohort analysis across three key dimensions.">
+  <img src="/images/insights.png" alt="Insights page showing acquisition quality, revenue, and churn prediction" />
 </Frame>
+
+<Note>Insights is available on Growth, Scale, and Enterprise plans. Free and trial workspaces see an upgrade prompt instead of the Insights page.</Note>
 
 ## Cohort Analysis
 
-Insights runs a weekly cohort analysis that answers four key questions about your users:
+Insights runs a cohort analysis that answers three key questions about your users:
 
 ### Acquisition Quality
 
-**Which channels produce users with the highest retention?**
+**Which channels bring in the most valuable users?**
 
-Acquisition Quality ranks your traffic sources by the retention rate of the users they bring in. Instead of optimizing for volume alone, you can identify which channels produce users that actually stick around.
+Acquisition Quality ranks your traffic sources by the visitors, wallets, and transactions they bring in, so you can quickly see which channels drive real activity rather than just traffic volume.
 
 Each channel shows:
 
 | Column | Description |
 |--------|-------------|
 | **Channel** | The traffic source (e.g., discord.com, google.com, t.co) |
-| **Users** | Number of users acquired from this channel |
-| **Retention** | Week-4 retention rate for users from this channel |
+| **Visitors** | Number of visitors from this channel |
+| **Wallets** | Number of wallets connected from this channel |
+| **Transactions** | Number of onchain transactions from users acquired via this channel |
 
-<Tip>Use this to shift acquisition spend toward channels that produce higher-quality users, not just more users.</Tip>
-
-### Activation - "Aha Moment"
-
-**Which early action predicts long-term retention?**
-
-Activation identifies the single event within a user's first few days that most strongly predicts long-term retention. This is the "aha moment" - the action that separates users who stay from those who churn.
-
-The insight shows:
-- **The event** that predicts retention (e.g., "Form Response Submitted")
-- **Time window** for the action (e.g., "within first 7 days")
-- **Retention lift** compared to users who don't perform this action (e.g., "+42% week-4 retention")
-
-<Tip>Once you identify your aha moment, design your onboarding to guide every new user toward that action as quickly as possible.</Tip>
+<Tip>Use this to shift acquisition spend toward channels that produce real onchain activity, not just visits.</Tip>
 
 ### Revenue Insights
 
@@ -69,11 +59,11 @@ For example:
 - **High risk**: "Users who trigger an error event have a 92% churn rate within the first 72 hours"
 - **Medium risk**: "Users who disconnect before completing onboarding rarely return"
 
-## Weekly Summary
+## Summary
 
-In addition to cohort analysis, the Insights page provides a weekly summary organized into four sections:
+In addition to cohort analysis, the Insights page provides a summary organized into four sections:
 
-- 🏆 **Wins** - Metrics that improved this week, with deltas and baselines
+- 🏆 **Wins** - Metrics that improved recently, with deltas and baselines
 - ⚠️ **Issues** - Performance drops or problems that need attention
 - 📈 **Opportunities** - Untapped segments or behaviors with estimated upside
 - ✅ **Actions** - Concrete action items with priority levels (High/Med/Low) and success metrics
@@ -83,16 +73,15 @@ In addition to cohort analysis, the Insights page provides a weekly summary orga
 1. Navigate to the [Formo Dashboard](https://app.formo.so)
 2. Select your project
 3. Click **Insights** in the left navigation (✨ sparkle icon)
-4. Insights are generated automatically each week - review the latest analysis and take action
+4. Insights refresh when you open the page (or once per day if you've already viewed it today) - review the latest analysis and take action
 
-<Info>Insights are generated using AI analysis of your actual analytics data. Results are cached daily and refresh automatically each week.</Info>
+<Info>Insights are generated using AI analysis of your actual analytics data. Insights refresh when you open the page and are then cached in your browser for the rest of the day, so reopening the page later the same day won't trigger a new analysis.</Info>
 
 ## Combining Insights with other features
 
 | Insight | Follow-up action |
 |---------|------------------|
 | **Low-quality acquisition channel** | Create a [segment](/features/wallet-intelligence/segments) of users from that channel to investigate |
-| **Aha moment identified** | Build a [funnel](/features/product-analytics/funnels) to measure how many users reach that event |
 | **Revenue decline in recent cohorts** | Use [retention analysis](/features/product-analytics/retention) to understand drop-off patterns |
 | **High churn signal detected** | Set up an [alert](/features/product-analytics/alerts) to notify you when users exhibit that behavior |
 | **Behavioral gap between power and casual users** | Explore the gap using [Ask AI](/features/product-analytics/ai) or the [Explorer](/features/product-analytics/explore) |
@@ -104,7 +93,7 @@ In addition to cohort analysis, the Insights page provides a weekly summary orga
     Dive deeper into cohort retention patterns
   </Card>
   <Card title="Funnels" icon="filter" href="/features/product-analytics/funnels">
-    Measure conversion toward your aha moment
+    Measure conversion toward a key event
   </Card>
   <Card title="User Segments" icon="users" href="/features/wallet-intelligence/segments">
     Create segments based on insight findings

--- a/features/product-analytics/insights.mdx
+++ b/features/product-analytics/insights.mdx
@@ -9,7 +9,7 @@ Track how user behavior evolves over time across different dimensions with AI-po
   <img src="/images/insights.png" alt="Insights page showing acquisition quality, revenue, and churn prediction" />
 </Frame>
 
-<Note>Insights is available on Growth, Scale, and Enterprise plans. Free and trial workspaces see an upgrade prompt instead of the Insights page.</Note>
+<Note>Insights isn't available during your trial period; trial workspaces see an upgrade prompt instead of the Insights page.</Note>
 
 ## Cohort Analysis
 

--- a/features/product-analytics/key-metrics.mdx
+++ b/features/product-analytics/key-metrics.mdx
@@ -56,7 +56,7 @@ See where your users are coming from by acquisition channel, referrer, UTM param
 
 ### Channels
 
-Formo automatically classifies every session into one of 13 acquisition channels using a priority-ordered ladder over the referrer domain, `utm_medium`, and 8 ad-platform click IDs (`gclid`, `gad_source`, `fbclid`, `msclkid`, `ttclid`, `twclid`, `li_fat_id`, `rdt_cid`). Classification happens at query time, so rule changes apply retroactively without backfills.
+Formo automatically classifies every session into one of 13 acquisition channels using a priority-ordered ladder over the referrer domain, `utm_medium`, and 8 ad-platform click IDs (`gclid`, `gad_source`, `fbclid`, `msclkid`, `ttclid`, `twclid`, `li_fat_id`, `rdt_cid`). Classification happens at ingestion time, so rule changes don't apply retroactively without a backfill.
 
 The 13 channels (first match wins):
 
@@ -64,7 +64,7 @@ The 13 channels (first match wins):
 2. **Paid Video** - paid traffic from YouTube, Vimeo, Twitch, Dailymotion, Loom, Wistia.
 3. **Paid Social** - paid traffic from Meta, X/Twitter, LinkedIn, Reddit, TikTok, Pinterest, Snapchat, Threads, Discord, Telegram, Farcaster, etc.
 4. **Email** - `utm_medium` of `email`, `e-mail`, `e_mail`, or `newsletter`.
-5. **Affiliates** - `utm_medium=affiliate` or any non-empty `ref` query parameter.
+5. **Referrals** - `utm_medium` is `affiliate` or `referral`, or any non-empty `ref` query parameter.
 6. **Display** - `utm_medium` of `display`, `banner`, `expandable`, or `interstitial`.
 7. **Paid Other** - a paid signal (paid `utm_medium` or click ID) that matched none of the above, with no recognized source or ad format. A catch-all so paid traffic is never relabelled as organic or Direct.
 8. **AI** - traffic from ChatGPT, Claude, Gemini, Copilot, Perplexity, DeepSeek, Phind, Poe, Mistral Chat, Meta AI, You.com, Pi. (No other analytics tool surfaces this yet.)

--- a/features/product-analytics/key-metrics.mdx
+++ b/features/product-analytics/key-metrics.mdx
@@ -56,7 +56,7 @@ See where your users are coming from by acquisition channel, referrer, UTM param
 
 ### Channels
 
-Formo automatically classifies every session into one of 13 acquisition channels using a priority-ordered ladder over the referrer domain, `utm_medium`, and 8 ad-platform click IDs (`gclid`, `gad_source`, `fbclid`, `msclkid`, `ttclid`, `twclid`, `li_fat_id`, `rdt_cid`). Classification happens at ingestion time, so rule changes don't apply retroactively without a backfill.
+Formo automatically classifies every session into one of 13 acquisition channels using a priority-ordered ladder over the referrer domain, `utm_medium`, and 8 ad-platform click IDs (`gclid`, `gad_source`, `fbclid`, `msclkid`, `ttclid`, `twclid`, `li_fat_id`, `rdt_cid`). Classification happens at ingestion time.
 
 The 13 channels (first match wins):
 

--- a/features/product-analytics/live-view.mdx
+++ b/features/product-analytics/live-view.mdx
@@ -11,10 +11,6 @@ See a realtime activity feed of your current visitors on a rotating globe. Perfe
 
 Click on any user or activity in the live feed to see where they are on the map. Click again to open their [wallet profile](/features/wallet-intelligence/wallet-profiles).
 
-<Note>
-  Live View requires a Growth, Scale, or Enterprise plan. On the free plan, the **Current Visitors** button is disabled with an upgrade prompt.
-</Note>
-
 ## When to use Live View
 
 Live View is great for:

--- a/features/product-analytics/live-view.mdx
+++ b/features/product-analytics/live-view.mdx
@@ -11,6 +11,10 @@ See a realtime activity feed of your current visitors on a rotating globe. Perfe
 
 Click on any user or activity in the live feed to see where they are on the map. Click again to open their [wallet profile](/features/wallet-intelligence/wallet-profiles).
 
+<Note>
+  Live View requires a Growth, Scale, or Enterprise plan. On the free plan, the **Current Visitors** button is disabled with an upgrade prompt.
+</Note>
+
 ## When to use Live View
 
 Live View is great for:

--- a/features/token-gated-forms/form-builder.mdx
+++ b/features/token-gated-forms/form-builder.mdx
@@ -10,7 +10,7 @@ description: 'Build and customize token-gated forms, waitlists, and surveys for 
 Launch forms, waitlists, and surveys for your community with the best form builder in web3.
 
 - 🔑 <a href="/features/token-gated-forms/token-gating">**Token gating.**</a> Gate access by token ownership, NFT collections, or other onchain credentials.
-- ✅ **Verified socials.** Verify Twitter accounts, Discord usernames, Farcaster, and more.
+- ✅ **Verified socials.** Verify Twitter accounts, Discord usernames, and more.
 - 🎨 **Custom branding.** Customize your backgrounds, colours, and logo to match your brand.
 - 🎨 **Template library.** Choose from a variety of form templates or build your own.
 - 🌐 <a href="/features/token-gated-forms/world-id">**World ID**</a> proof-of-personhood verification.
@@ -55,11 +55,10 @@ The form builder uses a drag-and-drop interface. Add fields by clicking the **+*
 | **Email** | Collect email addresses |
 | **Short Text** | Single-line responses |
 | **Long Text** | Multi-line responses |
-| **Multiple Choice** | Select one option from a list |
+| **Single Choice** | Select one option from a list |
 | **Checkboxes** | Select multiple options |
 | **Twitter** | Verify and capture Twitter handle |
 | **Discord** | Verify and capture Discord username |
-| **Farcaster** | Verify and capture Farcaster ID |
 
 ### Step 3: Enable token gating (optional)
 
@@ -161,7 +160,7 @@ Only users holding at least 1 NFT from your collection can submit the form.
     Yes. You can configure multiple token gate conditions and choose whether users must meet all conditions (AND) or any one condition (OR). See [token gating](/features/token-gated-forms/token-gating) for details on configuring multi-condition gates.
   </Accordion>
   <Accordion title="What social accounts can be verified on token-gated forms?">
-    You can verify Twitter/X, Discord, Farcaster, Telegram, and more. Additional verification options include Solana wallet, World ID, Human Passport, and Contract Read conditions. Social verification helps you build richer profiles and prevent sybil submissions.
+    You can verify Twitter/X, Discord, Telegram, and more. Additional verification options include Solana wallet, World ID, Human Passport, and Contract Read conditions. Social verification helps you build richer profiles and prevent sybil submissions.
   </Accordion>
   <Accordion title="Can I customize the branding and design of my form?">
     Yes. You can add your logo, set brand colors, customize the background, and configure the form layout. Forms are designed to be embeddable on your own site or shareable as standalone links.

--- a/features/wallet-intelligence/audience-insights.mdx
+++ b/features/wallet-intelligence/audience-insights.mdx
@@ -61,11 +61,11 @@ The dashboard shows key breakdowns of your audience:
 
 | Chart | What it shows |
 |-------|---------------|
-| **Net Worth Distribution** | Users grouped by wallet value ($0-1k, $1k-10k, $10k-100k, $100k+) |
+| **Net Worth Distribution** | Users grouped by wallet value ($0-$250, $250-$10K, $10K-$50K, $50K-$100K, $100K-$500K, $500K-$1M, $1M-$5M, $5M-$10M, $10M-$25M, $25M-$50M, $50M-$100M, $100M+) |
 | **Top Apps** | Most common crypto apps your users interact with |
 | **Top Tokens** | Most held tokens across your user base |
 | **Top Chains** | Which networks your users are active on |
-| **Lifecycle** | New, Returning, Power Users, Churned breakdown |
+| **Lifecycle** | New, Returning, Power user, Resurrected, At Risk, Churned breakdown |
 
 <Frame caption="See aggregate onchain data for your entire user base.">
 	<img src="/images/audience-insights.png" alt="Audience Insights" />
@@ -81,7 +81,7 @@ Click **Add Filter** to narrow down to specific user groups:
 |--------|-------|
 | Net Worth | > $10,000 |
 | Apps | Contains "Uniswap" |
-| Lifecycle | Power User |
+| Lifecycle | Power user |
 
 **Example: Find users from a specific campaign**
 
@@ -117,7 +117,7 @@ Turn useful filter combinations into reusable segments:
 ### Common analysis workflows
 
 **Understand your best users:**
-1. Filter by Lifecycle = "Power User"
+1. Filter by Lifecycle = "Power user"
 2. Look at Top Apps and Top Tokens
 3. Identify common characteristics to target in acquisition
 

--- a/features/wallet-intelligence/overview.mdx
+++ b/features/wallet-intelligence/overview.mdx
@@ -66,7 +66,7 @@ Formo automatically categorizes users by lifecycle stage based on their activity
 |-------|---------------|
 | **New** | Recent acquisition |
 | **Returning** | Engaged user |
-| **Power User** | Highly engaged |
+| **Power user** | Highly engaged |
 | **Resurrected** | Re-engaged after going quiet |
 | **At Risk** | Still active but going quiet |
 | **Churned** | Needs re-engagement |
@@ -79,7 +79,7 @@ Segments let you group users by shared characteristics. Here's how to create one
 
 1. Go to **Users** in the sidebar
 2. Apply filter conditions. For example:
-   - Lifecycle = "Power User"
+   - Lifecycle = "Power user"
    - Net worth > $10,000
    - Label = "Coinbase Verified Account"
 3. Click **Save as Segment**
@@ -111,7 +111,7 @@ Export this segment as CSV to run targeted re-engagement campaigns on social cha
     Formo aggregates onchain data across all major EVM chains to build wallet profiles. This includes token holdings, DeFi positions, wallet age, transaction frequency, and net worth. Data is refreshed periodically to keep profiles current.
   </Accordion>
   <Accordion title="How are wallet lifecycle stages calculated?">
-    Wallet lifecycle stages (New, Returning, Power User, Resurrected, At Risk, Churned) are calculated based on activity recency and frequency on your app, relative to a reference date that defaults to today. For example, a wallet last seen more than 30 days ago is classified as "Churned," while a wallet first seen 30+ days ago and active on 5+ of the last 30 days is a "Power User." Default thresholds can be customized in Settings → Lifecycle. See [wallet profiles](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for details.
+    Wallet lifecycle stages (New, Returning, Power user, Resurrected, At Risk, Churned) are calculated based on activity recency and frequency on your app, relative to a reference date that defaults to today. For example, a wallet last seen at least 30 days ago is classified as "Churned," while a wallet first seen more than 30 days ago and active on 5+ of the last 30 days is a "Power user." Default thresholds can be customized in Settings → Lifecycle. See [wallet profiles](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for details.
   </Accordion>
   <Accordion title="Can I export wallet profiles and segments for marketing campaigns?">
     Yes. You can export any [segment](/features/wallet-intelligence/segments) as a CSV file for use in targeted re-engagement campaigns. You can also query profiles programmatically via the [Profiles API](/api/profiles/get).

--- a/features/wallet-intelligence/segments.mdx
+++ b/features/wallet-intelligence/segments.mdx
@@ -23,7 +23,7 @@ Your segment is now saved and can be reused across the dashboard.
 Target exactly the right people based on any number or combination of conditions:
 - US Users: Users with the 'Coinbase Verified Country' label set to the US
 - Verified humans: Users with a 'Human Passport Unique Humanity Score' above 50
-- Power users with high balances: Users with the 'Power User' lifecycle label who have net worth above $1M
+- Power users with high balances: Users with the 'Power user' lifecycle label who have net worth above $1M
 - Dropped-Off Users: Users who did not come back the following week
 
 You can use <a href="/features/wallet-intelligence/wallet-labels">wallet labels</a>, offchain, and onchain properties to create your segments.

--- a/features/wallet-intelligence/wallet-labels.mdx
+++ b/features/wallet-intelligence/wallet-labels.mdx
@@ -17,15 +17,15 @@ Each tracked user on Formo is assigned labels based on their onchain activity an
 
 ### User lifecycle labels
 
-Every wallet is assigned a lifecycle stage based on its recency and active days: **New**, **Returning**, **Power User**, **Resurrected**, **At Risk**, or **Churned**. See [User lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
+Every wallet is assigned a lifecycle stage based on its recency and active days: **New**, **Returning**, **Power user**, **Resurrected**, **At Risk**, or **Churned**. See [User lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
 
 ### Attestations
 
 | Label | Description |
 |-------|-------------|
-| **Sanctioned User** | OFAC-sanction status and designations |
+| **OFAC Sanctioned** | OFAC-sanction status and designations |
 | **Human Passport Unique Humanity Score** | [Human Passport score (0-100)](https://docs.passport.xyz/) |
-| **Human Passport Aggregate Model Score** | [Aggregate unique humanity score for EVM wallets (0-100)](https://docs.passport.xyz/building-with-passport/models/available-models#aggregate-unique-humanity-model) |
+| **Human Passport Aggregate Model Score** | [Aggregate unique humanity score for EVM wallets (0-100, or -1 if there's insufficient transaction history)](https://docs.passport.xyz/building-with-passport/models/available-models#aggregate-unique-humanity-model) |
 | **Coinbase Verified Account** | [Coinbase verified account attestations](https://www.coinbase.com/developer-platform/products/verifications) |
 | **Coinbase Verified Country** | Coinbase verified country attestations with country code extraction |
 | **Coinbase One** | Coinbase One subscription attestations |
@@ -36,7 +36,7 @@ Every wallet is assigned a lifecycle stage based on its recency and active days:
 | Label | Description |
 |-------|-------------|
 | **Merkl Campaigns** | Tracks participation in [Merkl](https://merkl.xyz) incentive campaigns. Formo automatically detects campaign IDs from the Merkl API and stores them as a label on the wallet profile. You can filter users by campaign ID to measure the quality of users acquired through specific Merkl campaigns. |
-| **ERC-8004 AI Agent** | Automatically detects wallets registered as AI agents via the [ERC-8004](https://erc8004.org) standard. Formo queries onchain registries across 11+ chains to identify agent wallets and surfaces the agent name, ID, and reputation score on the wallet profile. |
+| **ERC-8004 AI Agent** | Automatically detects wallets registered as AI agents via the [ERC-8004](https://erc8004.org) standard. Formo queries onchain registries across 11 chains to identify agent wallets (agent discovery runs via subgraph on 5 of them; the rest are used for RPC and reputation lookups once an agent is found) and surfaces the agent name, ID, and reputation score on the wallet profile. |
 
 ---
 
@@ -75,9 +75,9 @@ Use labels to find specific user types:
 
 | Goal | Label Filter |
 |------|--------------|
-| Find power users | Lifecycle = "Power User" |
+| Find power users | Lifecycle = "Power user" |
 | Find verified humans | Human Passport Score > 50 |
-| Exclude sanctioned wallets | Label != "Sanctioned User" |
+| Exclude sanctioned wallets | Label != "OFAC Sanctioned" |
 | Find Coinbase users | Label = "Coinbase Verified Account" |
 
 ### Step 3: Combine labels with other filters
@@ -89,7 +89,7 @@ Labels become powerful when combined with other criteria:
 |--------|-------|
 | Apps | Uniswap, Aave (or other DeFi protocols) |
 | Net Worth | > $50,000 |
-| Lifecycle | Power User |
+| Lifecycle | Power user |
 
 **Verified users from campaigns:**
 | Filter | Value |
@@ -122,12 +122,12 @@ Turn useful label combinations into reusable segments:
 4. Use it to find similar users
 
 **Compliance filtering:**
-1. Filter by Label != "Sanctioned User"
+1. Filter by Label != "OFAC Sanctioned"
 2. Add Human Passport Score > 20 for sybil resistance
 3. Export clean lists for marketing or rewards
 
 **Quality scoring:**
-1. Combine multiple positive labels (Power User + Coinbase Verified Account + Human Passport Score > 50)
+1. Combine multiple positive labels (Power user + Coinbase Verified Account + Human Passport Score > 50)
 2. Users matching more labels = higher quality
 3. Prioritize multi-label users for outreach
 
@@ -142,7 +142,7 @@ Set up alerts based on labels:
 
 1. Go to **Settings** > **Alerts**
 2. Create a **User** alert
-3. Add filters: Lifecycle = "Power User" AND net_worth_usd > 100000, or Labels = your target label
+3. Add filters: Lifecycle = "Power user" AND net_worth_usd > 100000, or Labels = your target label
 4. Get notified within 5 minutes when a wallet matching those filters becomes active
 
 ### Next Steps

--- a/features/wallet-intelligence/wallet-profiles.mdx
+++ b/features/wallet-intelligence/wallet-profiles.mdx
@@ -27,13 +27,13 @@ Each user's lifecycle stage is computed relative to a **reference date** (the en
 | Lifecycle | Definition |
 |:----------|:------------|
 | **New** | First seen within the last 30 days and still active. |
-| **Power User** | First seen more than 30 days ago, still active, and active on at least 5 distinct days in the last 30 days. |
+| **Power user** | First seen more than 30 days ago, still active, and active on at least 5 distinct days in the last 30 days. |
 | **Resurrected** | First seen more than 30 days ago and re-engaged within the last 30 days after a 30+ day inactivity gap. |
 | **At Risk** | Previously active wallet whose activity has slowed but that hasn't churned yet: last seen at least 14 days ago, fewer than 5 active days in the last 30 days, and no 30+ day gap, with at least 1 active day in the prior 30 to 60 days. |
 | **Returning** | Established active users who don't fit another stage: active recently but not New, Power, Resurrected, or At Risk. |
-| **Churned** | Last seen more than 30 days ago. |
+| **Churned** | Last seen at least 30 days ago. |
 
-Stages are mutually exclusive and evaluated in precedence order: Churned, New, Power User, Resurrected, At Risk, Returning. **At Risk** carves out fading users that would otherwise sit in Returning, surfacing established wallets to re-engage before they churn.
+Stages are mutually exclusive and evaluated in precedence order: Churned, New, Power user, Resurrected, At Risk, Returning. **At Risk** carves out fading users that would otherwise sit in Returning, surfacing established wallets to re-engage before they churn.
 
 Filter users by lifecycle to create [segments](/features/wallet-intelligence/segments) and audiences. For example, "Show me whales who use app X who are power users" or "Show me high net worth wallets who are at risk."
 
@@ -74,6 +74,7 @@ Supported platforms:
 | **YouTube** | YouTube channel |
 | **Email** | Email address |
 | **Basenames** | Base chain name |
+| **Linea** | Linea Name Service (.linea) domain |
 | **Website** | Personal or project website |
 
 Social cards are displayed in a grid on the wallet profile page. Click any card to copy the handle or open the external profile.
@@ -86,7 +87,7 @@ The **Apps** tab shows a user's complete DeFi positions and portfolio across all
 |:-------|:------------|
 | **App** | Protocol name and logo (e.g., Aave, Uniswap, Lido) |
 | **Chain** | The blockchain network |
-| **Balance** | USD value of the position |
+| **Value** | USD value of the position |
 | **Portfolio %** | Percentage of the user's total DeFi portfolio |
 
 Filter by individual chain or view all positions at once. Apps are sorted by USD value from highest to lowest.
@@ -161,7 +162,7 @@ The profile header shows key information at a glance:
 | **Address** | Wallet address with copy button |
 | **ENS/Identity** | ENS name, Farcaster, Lens, or other identity |
 | **Net Worth** | Total value across all chains |
-| **Lifecycle** | New, Returning, Power User, Resurrected, At Risk, or Churned |
+| **Lifecycle** | New, Returning, Power user, Resurrected, At Risk, or Churned |
 | **First Seen** | When they first visited your app |
 | **Last Seen** | Most recent activity |
 
@@ -201,8 +202,8 @@ The **Labels** section shows auto-generated tags:
 
 | Label Type | Examples |
 |------------|----------|
-| **Lifecycle** | New, Returning, Power User |
-| **Attestations** | Sanctioned User, Human Passport score, Coinbase Verified Account, Coinbase Verified Country, Coinbase One |
+| **Lifecycle** | New, Returning, Power user |
+| **Attestations** | OFAC Sanctioned, Human Passport score, Coinbase Verified Account, Coinbase Verified Country, Coinbase One |
 | **Campaigns** | Merkl Campaigns |
 | **Agents** | ERC-8004 AI Agent |
 

--- a/guides/ask-ai.mdx
+++ b/guides/ask-ai.mdx
@@ -90,17 +90,11 @@ Recommended next steps based on your data
 ### Acquisition Quality
 Which channels bring the best LTV users?
 
-### Activation
-Which cohorts complete key actions fastest?
-
 ### Revenue
 Which cohorts spend the most onchain?
 
 ### Churn Prediction
 Which users are at risk of churning?
-
-### Behavioral Insights
-Common patterns in high-value users
 
 ## Part 6: Save Your Questions as Dashboards
 

--- a/guides/contract-events.mdx
+++ b/guides/contract-events.mdx
@@ -28,9 +28,8 @@ Click **Add Contract**. A modal opens.
 
 1. Paste your **contract address** (e.g., `0x6B175474E89094C44Da98b954EedeAC495271d0F` for DAI on Ethereum)
 2. Select the **chain** from the dropdown (Ethereum, Polygon, Arbitrum, Optimism, Base, etc.)
-3. Click **Auto-Detect ABI**
 
-Formo fetches the contract's ABI from Etherscan (or equivalent block explorer). If successful, you'll see a list of all events in the contract.
+Once both fields lose focus, Formo automatically fetches the contract's ABI in the background. If successful, you'll see a list of all events in the contract.
 
 If auto-detection fails, you can paste the ABI manually (copy from Etherscan, Hardhat build output, or your IDE).
 
@@ -56,11 +55,11 @@ Example: For a DEX, track Swap. For a token, track Transfer and Approval.
 
 Once events are selected, click **Deploy**. Formo provisions the pipeline in the background.
 
-Pipeline states progress as: **Draft** > **Initializing** > **Active**
+Pipeline states progress as: **Draft** > **Active** (shown as **Live** in the UI). A pipeline can also land in **Paused** or **Error** if something needs your attention.
 
 This typically takes a few minutes. Monitor the status in the Project Settings > Contracts panel.
 
-Once **Active**, your smart contract events will start flowing into your Formo project.
+Once **Live**, your smart contract events will start flowing into your Formo project.
 
 <Tip>
 You can add more contracts later. Just add it, select events, and deploy to update the pipeline.
@@ -182,7 +181,8 @@ Alerts notify you in real time, keeping you informed of important onchain activi
 
 In Project Settings > Contracts, each contract shows its pipeline state:
 - **Draft**: Not yet deployed
-- **Active**: Live and ingesting events
+- **Live**: Active and ingesting events
+- **Inactive**: Deployed but not currently ingesting events
 - **Paused**: Temporarily disabled
 - **Error**: Pipeline failed (check logs)
 
@@ -208,11 +208,11 @@ Once contract events are flowing, explore advanced use cases:
 <AccordionGroup>
 
 <Accordion title="What blockchains does Formo support for contract events?">
-Formo supports Ethereum, Polygon, Arbitrum, Optimism, Base, BNB Chain, Avalanche, Linea, Scroll, zkSync, Blast, and more. Full list at [Supported Chains](/chains/overview).
+Formo supports Ethereum, Polygon, Arbitrum, Optimism, Base, BNB Chain, Avalanche, Linea, Scroll, zkSync, and more. Full list at [Supported Chains](/chains/overview).
 </Accordion>
 
 <Accordion title="How does Formo detect contract ABIs automatically?">
-Formo queries Etherscan, Polygonscan, and other block explorers. If your contract is verified on the explorer, the ABI is detected instantly. If not, paste the ABI manually.
+Formo uses a single unified Etherscan API (selecting the chain via a chainId parameter) to fetch verified ABIs, with Sourcify as a fallback if the contract isn't verified there. If your contract is verified on either source, the ABI is detected instantly. If not, paste the ABI manually.
 </Accordion>
 
 <Accordion title="What happens if I add a contract that's not verified on Etherscan?">

--- a/guides/dau-tracking.mdx
+++ b/guides/dau-tracking.mdx
@@ -147,7 +147,7 @@ Not all active users are equal. Segment by behavior and value.
 
 Formo automatically categorizes users by lifecycle:
 
-Formo classifies every wallet into one lifecycle stage (**New**, **Returning**, **Power User**, **Resurrected**, **At Risk**, or **Churned**) based on activity recency and frequency. See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
+Formo classifies every wallet into one lifecycle stage (**New**, **Returning**, **Power user**, **Resurrected**, **At Risk**, or **Churned**) based on activity recency and frequency. See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
 
 View these segments by going to **Users** and applying the **Lifecycle** filter.
 

--- a/guides/flows.mdx
+++ b/guides/flows.mdx
@@ -26,7 +26,6 @@ In the flow builder, select your **starting event**. Common starting points for 
 
 - **First page view** (shows the complete user journey from landing)
 - **Connect wallet** (shows post-connection paths)
-- **Account Signup** (tracks authentication flow)
 
 For onboarding analysis, start with the **connect wallet event** to see what happens immediately after users authenticate.
 
@@ -72,11 +71,12 @@ Insight: If most successful users read your docs first, improve doc visibility o
 
 Click **Filter** to narrow the flow to specific user segments. Filter options:
 
-- **New Users Only** (lifecycle = New)
-- **By Referrer** (organic vs paid, specific campaigns)
 - **By Device** (mobile vs desktop dropoff patterns)
-- **By Wallet Label** (verified, high-net-worth wallets)
-- **By Chain** (Ethereum users vs Polygon users)
+- **By Country** (geographic patterns)
+- **By Browser**
+- **By OS**
+- **By Referrer** (organic vs paid, specific campaigns)
+- **By Referrer URL**
 
 Example: Compare flows for mobile users vs desktop. If mobile has 40% dropoff at wallet connect but desktop has 10%, your mobile UX needs work.
 
@@ -213,11 +213,11 @@ Yes. In the flow filter, add a condition like "Time Since Starting Event: < 24 h
 </Accordion>
 
 <Accordion title="What's the maximum number of steps a flow can show?">
-Flows can show up to 20 steps deep, though clarity typically degrades after 7-8 steps. If your flow is too complex, filter to new users only or segment by user property.
+Flows can show up to 5 steps deep. If your flow is too complex, segment by a user property like device or country to focus the view.
 </Accordion>
 
-<Accordion title="Can I export flow data as a CSV or JSON?">
-Yes. Click Export in the chart menu to download node and path data. Useful for reporting to stakeholders or further analysis in Excel.
+<Accordion title="Can I export flow data as a CSV?">
+Yes, but not the node and path structure itself. Click a node or path to select the users behind it, then export that user list as a CSV. There's no JSON export option. Useful for reporting to stakeholders or further analysis in Excel.
 </Accordion>
 
 </AccordionGroup>

--- a/guides/funnels.mdx
+++ b/guides/funnels.mdx
@@ -57,7 +57,7 @@ Select **connect** from the events list.
 </Step>
 
 <Step>
-(Optional) Add a filter to track only specific chains: Chain = "ethereum".
+(Optional) Add a filter to track only specific chains: chain_id = 1 (Ethereum mainnet).
 </Step>
 </Steps>
 
@@ -73,7 +73,7 @@ Select **transaction** from the events list. This counts users who completed an 
 </Step>
 
 <Step>
-(Optional) Add a filter: Contract Address = "0x..." to track swaps on your DEX only.
+(Optional) Add a filter: to = "0x..." to track swaps on your DEX only.
 </Step>
 </Steps>
 
@@ -95,31 +95,30 @@ Scroll to **Conversion Window** in the settings panel.
 </Step>
 
 <Step>
-Choose your window based on your funnel:
-- **1 day**: Fast decisions (DEX swaps, quick stakes)
-- **7 days**: Deliberate decisions (pool deposits, farm selections)
-- **14 days**: Default (balances most use cases)
-- **30 days**: Long consideration cycles (lending protocols, governance)
+Enter a number and choose a unit (Hours, Days, or Weeks). The default window is 2 days, but you can tune it to your funnel:
+- Short windows (hours): Fast decisions (DEX swaps, quick stakes)
+- A few days: Deliberate decisions (pool deposits, farm selections)
+- Weeks: Long consideration cycles (lending protocols, governance)
 </Step>
 </Steps>
 
-## Part 4: Choose Funnel Type
+## Part 4: Choose Step Order
 
-Formo supports two funnel types:
+Formo supports two step order modes:
 
-**Closed Funnel**
+**Sequential**
 Each step must follow the previous step. User must view a page, then connect, then swap. Most common.
 
-**Open Funnel**
+**Any order**
 Each step is independent. User can swap without connecting first (e.g., batch transactions, programmatic access). Choose this if your funnel steps can happen in any order.
 
 <Steps>
 <Step>
-Click the **Funnel Type** dropdown (default: Closed).
+Click the **Step order** dropdown (default: Sequential).
 </Step>
 
 <Step>
-Select **Open** only if your user journey allows non-sequential steps.
+Select **Any order** only if your user journey allows non-sequential steps.
 </Step>
 </Steps>
 
@@ -153,7 +152,6 @@ Select a dimension:
 - **Country**: Geographic patterns?
 - **Device**: Mobile vs desktop conversion?
 - **UTM Source**: Which campaign drives best users?
-- **Chain**: Which blockchain has highest conversion?
 </Step>
 
 <Step>
@@ -165,13 +163,13 @@ The funnel splits into multiple bands, one per breakdown value. Compare conversi
 
 ## Part 7: Use Conversion Insights
 
-Formo uses statistical analysis to find what drives conversions. Click the **Insights** tab (next to the funnel chart) to see:
+Formo analyzes your funnel data to find what drives conversions. Click the **Insights** tab (next to the funnel chart) to see:
 
 - **Lift**: Which attributes increase conversion probability
 - **Odds ratio**: How much more (or less) likely users with this attribute convert
-- **Statistical significance**: Is this insight real or noise
+- **Penetration**: How common this attribute is among your users
 
-Example insight: "Users from Referrer=twitter have 2.3x lift in Step 2 conversion (wallet connect). This is statistically significant (p < 0.05)."
+Example insight: "Users from Referrer=twitter have 2.3x lift in Step 2 conversion (wallet connect), with an odds ratio of 3.1."
 
 Act on this: Double down on Twitter traffic if wallet conversion is your bottleneck.
 
@@ -236,9 +234,9 @@ Liquidity provision funnels are longer because users must approve two tokens, th
 |------|-------|--------|
 | 1 | page | path = "/pool" |
 | 2 | connect | - |
-| 3 | approval_1 | function = "approve", token = "tokenA" |
-| 4 | approval_2 | function = "approve", token = "tokenB" |
-| 5 | addLiquidity | function = "addLiquidity" |
+| 3 | approval_1 | function_name = "approve", token = "tokenA" |
+| 4 | approval_2 | function_name = "approve", token = "tokenB" |
+| 5 | addLiquidity | function_name = "addLiquidity" |
 
 Two approval steps cause most drop-off.
 
@@ -248,12 +246,12 @@ Track the full lending funnel (Deposit > Borrow > Repay):
 
 | Step | Event | Filter |
 |------|-------|--------|
-| 1 | deposit | function = "supply" |
-| 2 | borrow | function = "borrow" |
+| 1 | deposit | function_name = "supply" |
+| 2 | borrow | function_name = "borrow" |
 | 3 | swap | (optional) use borrowed assets |
-| 4 | repay | function = "repay" |
+| 4 | repay | function_name = "repay" |
 
-Use **Open Funnel** here (borrow and swap may happen out of order).
+Use **Any order** step order here (borrow and swap may happen out of order).
 
 ### Key DeFi Drop-Off Patterns
 
@@ -270,7 +268,7 @@ Common friction points and solutions:
 Monitor high-value swaps on your DEX:
 
 1. Create a funnel with step: **transaction** + filter **amount_usd > 100000**
-2. Add breakdown by **user_address** to spot repeat whale traders
+2. Add breakdown by **address** to spot repeat whale traders
 3. Set an [alert](/features/product-analytics/alerts) to get notified when whale wallets transact
 4. Use **Insights** to find attributes of whale traders and target similar users
 
@@ -300,18 +298,19 @@ Your conversion funnel is live. Next steps:
 Yes. If you've set up [Contract Events](/guides/contract-events), you can select any of them in the funnel builder. For example, a Uniswap funnel might be: "page" > "swap (contract event)" > "Transfer (contract event)".
 </Accordion>
 
-<Accordion title="What's the difference between closed and open funnels?">
-**Closed funnel**: User must complete steps in order. Page view, then wallet connect, then swap.
+<Accordion title="What's the difference between sequential and any-order step order?">
+**Sequential**: User must complete steps in order. Page view, then wallet connect, then swap.
 
-**Open funnel**: Steps are independent. User can swap without a page view event (e.g., direct contract calls, wallet batch operations). Use open funnels when your steps can happen in any sequence.
+**Any order**: Steps are independent. User can swap without a page view event (e.g., direct contract calls, wallet batch operations). Use any-order step order when your steps can happen in any sequence.
 </Accordion>
 
 <Accordion title="What conversion window should I use?">
-- **Swap, stake, claim**: 1 day (fast decisions)
-- **Pool deposits, farming**: 7 days (deliberate)
-- **Loans, governance**: 14-30 days (long consideration)
+Enter a number and pick a unit (Hours, Days, or Weeks):
+- **Swap, stake, claim**: hours (fast decisions)
+- **Pool deposits, farming**: a few days (deliberate)
+- **Loans, governance**: weeks (long consideration)
 
-Start with 14 days (default) and adjust based on your product.
+Start with the default of 2 days and adjust based on your product.
 </Accordion>
 
 </AccordionGroup>

--- a/guides/onchain-attribution.mdx
+++ b/guides/onchain-attribution.mdx
@@ -189,26 +189,12 @@ Formo supports multiple attribution models. Each gives credit differently.
 
 → Direct gets 100% credit
 
-### Linear attribution
-
-**How it works:** Credit split equally across all touchpoints.
-
-**Best for:** Valuing the entire journey.
-
-**Example:**
-1. User finds you via Twitter
-2. Returns via Discord link
-3. Converts via direct visit
-
-→ Each gets 33% credit
-
 ### Which model to use?
 
 | Goal | Model | Why |
 |------|-------|-----|
 | Grow awareness | First-touch | Shows which channels introduce new users |
 | Optimize conversions | Last-touch | Shows what pushes users to convert |
-| Balanced view | Linear | Values the full journey |
 
 
 ## Part 5: How to Analyze Attribution in Formo
@@ -412,7 +398,7 @@ Yes. When a user lands on your app with UTM parameters in the URL, Formo capture
 </Accordion>
 
 <Accordion title="What happens if a user visits from multiple sources before converting?">
-Formo records both first-touch and last-touch attribution. You can view either model in the Overview page to understand the full user journey.
+Formo records both first-touch and last-touch attribution. You can view either model on the Users page to understand the full user journey.
 </Accordion>
 
 <Accordion title="Can I use both UTM parameters and ref codes on the same link?">

--- a/guides/retention.mdx
+++ b/guides/retention.mdx
@@ -8,35 +8,9 @@ keywords: ["crypto retention analytics", "DeFi user retention", "web3 churn anal
 
 Acquiring users is expensive. Keeping them is where the real growth happens. In crypto, a 10 percent improvement in Day 7 retention can be worth thousands in LTV. This guide shows you how to measure retention, spot churn, and re-engage at-risk users.
 
-## Part 1: View Retention on the Overview Page
+## Part 1: Build a Retention Cohort Chart
 
-The fastest way to see retention is on your **Overview** dashboard:
-
-<Steps>
-<Step>
-Open the **Overview** page in Formo.
-</Step>
-
-<Step>
-Scroll down to the **Retention** section. You'll see:
-- **Day 7 Retention**: Percent of users active on Day 7 (default 14-day window)
-- **Day 30 Retention**: Percent of users active on Day 30
-- **Day 90 Retention**: Percent of users active on Day 90
-- **Delta**: Week-over-week change (up or down)
-</Step>
-
-<Step>
-Compare your retention to your baseline. A 2-3 percent week-over-week improvement is excellent. A 5+ percent drop is a red flag.
-</Step>
-</Steps>
-
-<Frame caption="Retention metrics on the Overview page">
-<img src="/images/screenshots/overview.png" alt="Overview retention" />
-</Frame>
-
-## Part 2: Build a Retention Cohort Chart
-
-For deeper insights, create a retention cohort chart on a dashboard. This shows how each cohort of users (grouped by signup date) retains over time:
+Create a retention cohort chart on a dashboard. This shows how each cohort of users (grouped by signup week) retains over time:
 
 <Steps>
 <Step>
@@ -44,10 +18,10 @@ Click **Dashboards** → **Add Chart** → select **Retention** chart type.
 </Step>
 
 <Step>
-Choose your **cohort grouping**:
-- **Daily**: See retention of users who signed up on each day
-- **Weekly**: Group by signup week (cleaner view for smaller apps)
-- **Monthly**: For apps with high volume
+Configure the chart:
+- **Retention Type**: Recurring (any return counts) or Rolling (must retain consecutively)
+- **Signal**: Base retention on a specific event, or on a user label
+- Cohorts are grouped weekly
 </Step>
 
 <Step>
@@ -65,7 +39,7 @@ The retention table shows cohorts (rows) and retention days (columns). Green cel
 <img src="/images/retention.png" alt="Retention table" />
 </Frame>
 
-## Part 3: Identify Churn Patterns
+## Part 2: Identify Churn Patterns
 
 The **Insights** page uses AI to spot churn signals. Check it weekly:
 
@@ -91,7 +65,7 @@ Click on an insight to drill into the data. Ask: Is this a real problem or noise
 - A specific geography or device churning faster suggests a UX or localization problem
 - A cohort that performs poorly across all retention windows suggests they were bad-fit users to begin with
 
-## Part 4: Segment Churned and At-Risk Users
+## Part 3: Segment Churned and At-Risk Users
 
 To re-engage users, you must first identify them. Use the **Users** page to create segments:
 
@@ -103,7 +77,7 @@ Click **Users** in the sidebar to see all users.
 <Step>
 Apply filters to find at-risk users:
 - **Lifecycle = "Churned"**: Users inactive for 30+ days
-- **Lifecycle = "Resurrecting"**: Users who returned after being inactive
+- **Lifecycle = "Resurrected"**: Users who returned after being inactive
 - **Last Activity < 7 days ago**: Users who haven't returned this week
 </Step>
 
@@ -121,12 +95,12 @@ Once saved, you can export this segment as CSV for re-engagement campaigns or us
 </Frame>
 
 <Note>
-**User Lifecycle Stages:** New, Returning, Power User, Resurrected, At Risk, and Churned, assigned from each wallet's activity recency and frequency. See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
+**User Lifecycle Stages:** New, Returning, Power user, Resurrected, At Risk, and Churned, assigned from each wallet's activity recency and frequency. See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
 
 Use these stages to build segments for targeted campaigns.
 </Note>
 
-## Part 5: Export Your Segment for Re-Engagement
+## Part 4: Export Your Segment for Re-Engagement
 
 <Steps>
 <Step>
@@ -145,7 +119,7 @@ Use this list to:
 </Step>
 </Steps>
 
-## Part 6: Set Up Alerts for Key User Events
+## Part 5: Set Up Alerts for Key User Events
 
 Monitor important user activity with alerts. Get notified when high-value wallets connect or key events happen:
 
@@ -169,7 +143,7 @@ Save. You'll be alerted in real time when the event fires.
 
 See [Alerts documentation](/features/product-analytics/alerts) for full setup.
 
-## Part 7: Use Ask AI to Understand Churn
+## Part 6: Use Ask AI to Understand Churn
 
 Open **Ask AI** (the AI assistant) and ask natural language questions:
 
@@ -327,8 +301,8 @@ All three matter. Day 7 catches immediate churn. Day 30 shows if you built a hab
 
 <Accordion title="What user lifecycle stage should I re-engage first?">
 Priority order:
-1. **Resurrecting**: Users who just came back. Momentum is on your side.
-2. **At-risk Returning**: Users with only 2-3 sessions. Easy to convert to Power Users.
+1. **Resurrected**: Users who just came back. Momentum is on your side.
+2. **At-risk Returning**: Users with only 2-3 sessions. Easy to convert to Power users.
 3. **Recent Churned**: Users inactive for 30-60 days. Still remember your product.
 4. **Old Churned**: Users inactive for 6+ months. Hard to re-activate.
 

--- a/guides/sql-explorer.mdx
+++ b/guides/sql-explorer.mdx
@@ -225,7 +225,7 @@ FROM (
 GROUP BY user_type
 ```
 
-This is a simple session-count split. Formo's built-in [user lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) (New, Returning, Power User, Resurrected, At Risk, Churned) uses recency and active days instead.
+This is a simple session-count split. Formo's built-in [user lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) (New, Returning, Power user, Resurrected, At Risk, Churned) uses recency and active days instead.
 
 ### Query 8: Whale Analysis
 
@@ -327,7 +327,7 @@ Supported tools:
 - Power BI
 - Custom integrations
 
-Configuration details are at [/data/bi](/data/bi). You'll need your API key from [Workspace Settings > API Keys](/api/authentication).
+Configuration details are at [/data/bi](/data/bi). You'll need your BI Read Key from Project Settings → Credentials (this is separate from your workspace API key).
 
 Example Metabase connection:
 1. In Metabase, click Settings > Databases > Add Database

--- a/guides/wallet-segmentation.mdx
+++ b/guides/wallet-segmentation.mdx
@@ -23,7 +23,7 @@ Each row is a wallet. Every column is filterable. This is your segmentation star
 
 Click the **Filter** button to add conditions. You can filter by:
 
-- **Lifecycle**: New, Returning, Power User, Resurrected, At Risk, Churned
+- **Lifecycle**: New, Returning, Power user, Resurrected, At Risk, Churned
 - **Net Worth**: Exact ranges ($0-$10k, $10k-$100k, $100k+, custom)
 - **Wallet Labels**: Verified accounts, sanctions flags, passport scores
 - **Apps Used**: Filter to users who used specific dapps
@@ -88,7 +88,8 @@ Target high-net-worth users who are brand new.
 Filter config:
 - Net Worth: > $100,000
 - Lifecycle: New
-- Sessions: = 1
+
+Note: There's no "Sessions" filter in the Users page UI (session count is only queryable via [SQL Explorer](/guides/sql-explorer)). Lifecycle: New already narrows this to wallets in their first lifecycle stage.
 
 
 ### Recipe 2: Churned Power Users
@@ -97,8 +98,8 @@ Re-engage users who were once active but disappeared.
 
 Filter config:
 - Lifecycle: Churned
-- Sessions: > 10
-- No Activity: > 30 days
+
+Note: There's no "Sessions" or "No Activity" filter in the Users page UI. Lifecycle: Churned already selects wallets that have gone quiet; for a precise session-count or days-since-last-activity threshold, query `num_sessions` and `last_seen` via [SQL Explorer](/guides/sql-explorer).
 
 
 ### Recipe 3: Campaign Converts
@@ -127,7 +128,8 @@ Wake up large wallets that haven't returned recently.
 Filter config:
 - Net Worth: > $50,000
 - Lifecycle: Churned OR Returning
-- Last Activity: > 14 days ago
+
+Note: There's no "Last Activity" filter in the Users page UI. Lifecycle already reflects recency (Churned means gone quiet, Returning means recently reactivated); for a precise days-since-last-activity threshold, query `last_seen` via [SQL Explorer](/guides/sql-explorer).
 
 
 ## Targeting Recipes for Campaigns
@@ -149,7 +151,7 @@ Filter config:
 |--------|-----------|
 | Apps Used | Uniswap, Aave (or other DeFi protocols) |
 | Net Worth | > $50,000 |
-| Lifecycle | Power User OR Returning |
+| Lifecycle | Power user OR Returning |
 
 **Recipe: Churned Whales**
 
@@ -157,7 +159,6 @@ Filter config:
 |--------|-----------|
 | Net Worth | > $100,000 |
 | Lifecycle | Churned |
-| Last Activity | > 30 days ago |
 
 **Recipe: Competitor Users**
 

--- a/integrations/dune.mdx
+++ b/integrations/dune.mdx
@@ -28,8 +28,11 @@ SELECT * FROM dune.ethereum.transactions
 ```
 
 <Note>
-  A query can only use **one** engine. You can't join a `dune` table with a
-  Formo table in the same query; they're separate databases.
+  Stick to **one** engine per query. Formo and Dune are separate databases,
+  so mixing `dune` tables with Formo tables in the same query (e.g. a join)
+  isn't meaningful. The editor shows a warning if it detects mixed engines,
+  but this is advisory: a cosmetic hint, not a rule the backend validates or
+  blocks.
 </Note>
 
 ## Add your Dune API key

--- a/intro.mdx
+++ b/intro.mdx
@@ -72,7 +72,7 @@ The Formo SDK source code is fully open source and [available on Github](https:/
 ## Next Steps
 
 <Steps>
-  <Step title="Get started for free">
+  <Step title="Get started">
     [Sign up](https://app.formo.so) and create your workspace.
   </Step>
   <Step title="Install Formo">

--- a/mcp/api-key.mdx
+++ b/mcp/api-key.mdx
@@ -22,7 +22,7 @@ https://api.formo.so/v0/mcp/
 </Note>
 
 <Note>
-  MCP requires a **Scale or Enterprise** plan. Connections from Free or Growth workspaces are rejected with a `403` error, even with a valid API key. [Upgrade your workspace](https://app.formo.so) to enable MCP access.
+  MCP requires a **Scale or Enterprise** plan. Connections from Growth workspaces are rejected with a `403` error, even with a valid API key. [Upgrade your workspace](https://app.formo.so) to enable MCP access.
 </Note>
 
 ## Create an API key
@@ -204,7 +204,7 @@ Select your client below to configure Formo with API key authentication.
 
 ## Troubleshooting
 
-**`403 MCP access requires a Scale or Enterprise plan`:** MCP is available only on Scale and Enterprise plans. A valid API key with the MCP scope is not sufficient on Free or Growth workspaces. [Upgrade your workspace](https://app.formo.so) to connect MCP.
+**`403 MCP access requires a Scale or Enterprise plan`:** MCP is available only on Scale and Enterprise plans. A valid API key with the MCP scope is not sufficient on a Growth workspace. [Upgrade your workspace](https://app.formo.so) to connect MCP.
 
 **Tools not appearing:** Verify your API key has the MCP scope enabled. Check that the URL ends with a trailing slash: `https://api.formo.so/v0/mcp/`. Restart your AI assistant after configuration changes.
 

--- a/mcp/oauth.mdx
+++ b/mcp/oauth.mdx
@@ -24,7 +24,7 @@ https://api.formo.so/v0/mcp/
 </Note>
 
 <Note>
-  MCP requires a **Scale or Enterprise** plan. The plan is enforced during the OAuth flow: Free and Growth workspaces cannot complete authorization and receive a `403` error. [Upgrade your workspace](https://app.formo.so) to enable MCP access.
+  MCP requires a **Scale or Enterprise** plan. The plan is enforced during the OAuth flow: Growth workspaces cannot complete authorization and receive a `403` error. [Upgrade your workspace](https://app.formo.so) to enable MCP access.
 </Note>
 
 ## When to use OAuth
@@ -186,7 +186,7 @@ Use a Workspace API Key when your MCP client supports custom request headers and
 
 ## Troubleshooting
 
-**`403 MCP access requires a Scale or Enterprise plan`:** The signed-in workspace is on a Free or Growth plan. MCP authorization is gated server-side, so the OAuth flow will not complete. [Upgrade the workspace](https://app.formo.so) to a Scale or Enterprise plan, then reconnect.
+**`403 MCP access requires a Scale or Enterprise plan`:** The signed-in workspace is on a Growth plan. MCP authorization is gated server-side, so the OAuth flow will not complete. [Upgrade the workspace](https://app.formo.so) to a Scale or Enterprise plan, then reconnect.
 
 **Client does not start OAuth:** Confirm the MCP server URL is exactly `https://api.formo.so/v0/mcp/` and includes the trailing slash.
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -17,7 +17,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open 
 - "Which pages have the highest bounce rate?"
 
 <Warning>
-  The Formo MCP server requires a **Scale or Enterprise** plan. This applies to both OAuth and Workspace API key connections. Free and Growth workspaces cannot connect to MCP and will receive a `403` error (`MCP access requires a Scale or Enterprise plan`). [Upgrade your workspace](https://app.formo.so) to enable MCP access.
+  The Formo MCP server requires a **Scale or Enterprise** plan. This applies to both OAuth and Workspace API key connections. Growth workspaces cannot connect to MCP and will receive a `403` error (`MCP access requires a Scale or Enterprise plan`). [Upgrade your workspace](https://app.formo.so) to enable MCP access.
 </Warning>
 
 ## Getting started

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -462,7 +462,7 @@ The SDK skips tracking in localhost by default.
 To enable tracking locally during development, set `tracking` to `true`:
 
 ```tsx
-<AnalyticsProvider
+<FormoAnalyticsProvider
     writeKey={WRITE_KEY}
     options={{
         tracking: true, // enable tracking on localhost
@@ -475,7 +475,7 @@ To enable tracking locally during development, set `tracking` to `true`:
 Control the level of logs the SDK prints to the console with the following logLevel settings:
 
 ```tsx
-<AnalyticsProvider
+<FormoAnalyticsProvider
     writeKey={WRITE_KEY}
     options={{
         logger: {
@@ -486,13 +486,15 @@ Control the level of logs the SDK prints to the console with the following logLe
 >
 ```
 
+Logging is disabled by default (`logger.enabled: false`); no logs print unless you explicitly set `logger.enabled: true`. The `levels` array is matched exactly, not hierarchically: setting `levels: ["warn"]` shows only `warn` messages, not `warn` and `error` together. List every level you want to see.
+
 | Log Level | Description |
 |-----------|-------------|
 | trace | Shows the most detailed diagnostic information, useful for tracing program execution flow. |
 | debug | Shows all messages, including function context information for each public method the SDK invokes. |
 | info | Shows informative messages about normal application operation. |
-| warn | Default. Shows error and warning messages. |
-| error | Shows error messages only. |
+| warn | Shows warning messages. |
+| error | Shows error messages. |
 
 ### Autocapture
 
@@ -526,11 +528,11 @@ const analytics = await FormoAnalytics.init('YOUR_API_KEY', {
 To support high-performance environments, the SDK sends events in batches. 
 
 ```tsx
-<AnalyticsProvider
+<FormoAnalyticsProvider
     writeKey={WRITE_KEY}
     options={{
         flushAt: 20, // defaults to batches of 20 events
-        flushInterval: 1000 * 60, // defaults to 1 min
+        flushInterval: 1000 * 30, // defaults to 30 seconds
     }}
 >
 ```
@@ -542,7 +544,7 @@ Customize this behavior with the `flushAt` and `flushInterval` configuration par
 The `ready` callback function executes once the Formo SDK is fully loaded and ready to use. This is useful for performing initialization tasks or calling SDK methods that require the SDK to be ready.
 
 ```tsx
-<AnalyticsProvider
+<FormoAnalyticsProvider
     writeKey={WRITE_KEY}
     options={{
         ready: function(formo) {
@@ -719,14 +721,14 @@ const analytics = await FormoAnalytics.init('YOUR_API_KEY', {
 
 ### Referrals
 
-Formo autodetects `ref`, `referral`, and `refcode` query parameters in the URL. You can customize how referrals are detected by the SDK:
+Formo autodetects `ref`, `referral`, `refcode`, `af`, and `referrer` query parameters in the URL. You can customize how referrals are detected by the SDK:
 
 ```tsx
 <FormoAnalyticsProvider
   writeKey="<YOUR_WRITE_KEY>"
   options={{
     referral: {
-      queryParams: ['via', 'ref'],      // Query params to detect (default: ['ref', 'referral', 'refcode'])
+      queryParams: ['via', 'ref'],      // Query params to detect (default: ['ref', 'referral', 'refcode', 'af', 'referrer'])
       pathPattern: '/referral/([^/]+)', // Regex to extract referral code from the URL path
     },
   }}
@@ -951,7 +953,7 @@ module.exports = {
 Then, configure the Formo SDK to send requests via your rewrite. Update the `apiHost` parameter in the Formo SDK:
 
 ```javascript
-<AnalyticsProvider
+<FormoAnalyticsProvider
   writeKey={WRITE_KEY}
   options={{
     apiHost: "/api/ingest",
@@ -1006,7 +1008,7 @@ In this file, set up code to match requests to a custom route, set a new host he
 Once done, configure the Formo SDK to send requests via your rewrite:
 
 ```javascript
-<AnalyticsProvider
+<FormoAnalyticsProvider
   writeKey={WRITE_KEY}
   options={{
     apiHost: "https://your-host-url.com/ingest",

--- a/security/mfa.mdx
+++ b/security/mfa.mdx
@@ -76,7 +76,7 @@ Once verified, MFA is active on your account. You'll be prompted for a TOTP code
 
 ## Account recovery
 
-If you lose access to your authenticator device, contact your organization administrator or reach out to [support@formo.so](mailto:support@formo.so). An administrator can reset your MFA so you can re-enroll with a new device.
+If you lose access to your authenticator device, contact [support@formo.so](mailto:support@formo.so). MFA resets must go through Formo support: your workspace Owner or Admin cannot reset another user's MFA themselves (they can only see whether MFA is enabled or disabled for a member). Formo support will verify your identity and reset your MFA so you can re-enroll with a new device.
 
 ## Next steps
 

--- a/security/overview.mdx
+++ b/security/overview.mdx
@@ -158,7 +158,7 @@ For the CDN script tag method, enable [SRI](/security/sri) and [CSP](/security/c
     Use [Subresource Integrity (SRI)](/security/sri) to verify SDK integrity, configure a [Content Security Policy (CSP)](/security/csp) to control allowed domains, and set up a [reverse proxy](/sdks/web#proxy) to route requests through your own domain.
   </Accordion>
   <Accordion title="Does Formo support SSO and role-based access control?">
-    Yes. Formo supports [Single Sign-On (SSO)](/security/sso) for centralized authentication through your identity provider, [multi-factor authentication (MFA)](/security/mfa) via TOTP, and [role-based access control](/security/roles) with Owner, Admin, Editor, and Member roles.
+    Yes. Formo supports [Single Sign-On (SSO)](/security/sso) for centralized authentication through your identity provider, [multi-factor authentication (MFA)](/security/mfa) via TOTP, and [role-based access control](/security/roles) with Owner, Admin, Editor, and Viewer roles.
   </Accordion>
 </AccordionGroup>
 

--- a/security/roles.mdx
+++ b/security/roles.mdx
@@ -50,6 +50,7 @@ Formo uses workspace roles to control what each teammate can view or change.
 | Explorer (SQL editor and wallet search) | ✅ | ✅ | ✅ | ❌ |
 | **Users** | | | | |
 | View wallet profiles | ✅ | ✅ | ✅ | ✅ |
+| View sensitive profile data (wallet labels, socials, clusters, custom properties) | ✅ | ✅ | ✅ | ✅* |
 | Import wallets | ✅ | ✅ | ✅ | ❌ |
 | Edit profile properties and labels | ✅ | ✅ | ✅ | ❌ |
 | **Alerts** | | | | |
@@ -68,3 +69,5 @@ Formo uses workspace roles to control what each teammate can view or change.
 | View audit logs | ✅ | ✅ | ❌ | ❌ |
 | **Agent Memory (Ask AI)** | | | | |
 | Manage agent memory | ✅ | ✅ | ❌ | ❌ |
+
+\* Sensitive profile data (wallet labels, socials, clusters, and custom properties) is visible to Viewers by default. An Owner or Admin can hide this data from Viewers with a per-project setting.


### PR DESCRIPTION
Comprehensive accuracy sweep across the docs site, verified directly against ../formono, ../sdk, ../sdk-node, and ../sdk-react-native source code. Highlights:

- sdks/web.mdx: fix 6 code samples using a nonexistent <AnalyticsProvider> component (real export is FormoAnalyticsProvider), wrong flushInterval default (60s -> 30s), wrong default-logging/hierarchy claims, and a stale 3-param referral list (real default has 5).
- features/product-analytics/custom-events.mdx: fix a code sample importing useFormoAnalytics, a hook renamed to useFormo over a year ago and no longer exported.
- data/catalog.mdx: rewrite the sessions table (wrong aggregate types, 8 fabricated columns, 4 missing real ones) and fix user_profiles_mv, anonymous_users, events, and revenue table types/columns to match the actual Tinybird schemas; fix the two example queries that broke as a result.
- api/openapi.json: fix Idempotency-Key incorrectly advertised on 3 profile endpoints that never honor it, message_id wrongly marked required, add an undocumented 202 "processing" response, fix AnalyticsBehaviorFilters' count/times mismatch, and fix ChartSettings/ConversionWindow bounds and enums (chart_type missing "area", breakdown missing 2 values, maxSteps/nodesPerStep wrongly capped at 10 instead of 5/8).
- api/boards/create-chart.mdx: fix the same chart-settings issues in both copies of this page's duplicated body, and correct the 201 response documentation (returns the full chart object, not a bare ID string).
- Lifecycle stage naming: fix "Power User" -> "Power user" (the real enum value) everywhere it's used as a filter value, since the wrong casing breaks exact-match filters.
- features/product-analytics/insights.mdx: remove a "weekly auto-refresh" cadence claim (real: on-demand, cached per day) and an entire "Activation" section describing a feature removed from the product; add a missing paid-plan gating note.
- guides/retention.mdx: remove a fabricated "View Retention on the Overview Page" section; fix the retention chart's cohort-grouping description to match the real controls.
- Numerous smaller fixes: wrong filter field names across several guides (chain_id vs "Chain", function_name vs "function", address vs "user_address", etc.), wrong chain-support checkmarks in chains/overview.mdx, removed Farcaster from form-builder.mdx (support was removed from the product), fixed MFA-reset and RBAC claims in the security docs, and more.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786542432&installation_id=130740768&pr_number=101&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F101&signature=104480bfa8ff3ef86a4f97b72cc00fce4c7887a55b0954b57376132fa1b5eb6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->