### PR TITLE
docs: refine copy

### DIFF
--- a/api/query/funnel.mdx
+++ b/api/query/funnel.mdx
@@ -16,7 +16,7 @@ Set `group_by` to a dimension (`device`, `browser`, `os`, `location`, `referrer`
 
 ## Defining steps
 
-The `steps` query parameter is a JSON-encoded array of 2–10 step specs. Each step is `{type, event, name, filters?: [...]}`:
+The `steps` query parameter is a JSON-encoded array of 2 to 10 step specs. Each step is `{type, event, name, filters?: [...]}`:
 
 - **`type`** - event type (`event` for page views, `track` for custom events, `transaction`, `signature`, `decoded_log`).
 - **`event`** - the event name to match.

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CLI Overview"
+title: "CLI overview"
 sidebarTitle: "Overview"
 icon: terminal
 description: "Query wallet profiles, run SQL analytics, manage dashboards, alerts, contracts, segments, and more - directly from your terminal or via AI agents."

--- a/features/product-analytics/custom-events.mdx
+++ b/features/product-analytics/custom-events.mdx
@@ -97,9 +97,9 @@ After tracking events:
 3. See all event occurrences
 
 Custom events also appear in:
-- [**Wallet Profiles**](/features/wallet-intelligence/wallet-profiles) – User's activity history
-- [**Funnels**](/features/product-analytics/funnels) – As conversion steps
-- [**Charts**](/features/product-analytics/charts) – Query with SQL
+- [**Wallet Profiles**](/features/wallet-intelligence/wallet-profiles): user's activity history
+- [**Funnels**](/features/product-analytics/funnels): as conversion steps
+- [**Charts**](/features/product-analytics/charts): query with SQL
 
 ### Best practices
 

--- a/features/product-analytics/key-metrics.mdx
+++ b/features/product-analytics/key-metrics.mdx
@@ -94,7 +94,7 @@ The Formo SDK automatically adds the following UTM parameters present on the pag
 
 ### Referrer URL tracking
 
-Referrer URL tracking lets you understand the specific URL where your users are coming from – as long as the site has the correct `Referer-Policy` header set.
+Referrer URL tracking lets you understand the specific URL where your users are coming from, as long as the site has the correct `Referer-Policy` header set.
 
 We recommend setting the `no-referrer-when-downgrade` <a target="_blank" rel="noopener noreferrer" href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#no-referrer-when-downgrade">policy</a>, which will only send the domain, path, and query parameters to the destination URL as long as the protocol security level stays the same (i.e. `HTTP` → `HTTP`, or `HTTPS` → `HTTPS`).
 

--- a/install.mdx
+++ b/install.mdx
@@ -207,7 +207,7 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
 
   ## **5. CRITICAL INSTRUCTIONS FOR AI MODELS**
 
-  ### **5.1 – ALWAYS DO THE FOLLOWING**
+  ### **5.1: ALWAYS DO THE FOLLOWING**
   1. **Detect the framework** (Wagmi, React, Next.js App Router, or Next.js Pages Router) and use the matching approach.
   2. **Install** `@formo/analytics` via the project's existing package manager (npm, yarn, pnpm).
   3. **Wrap** the app with `<FormoAnalyticsProvider>`. For Wagmi, place it inside `<WagmiProvider>` and `<QueryClientProvider>`.
@@ -219,7 +219,7 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
   9. **Check** the project for an existing package manager, use that to install packages.
   10. For **Wagmi**, transaction and signature autocapture only works with wagmi React hooks (`useWriteContract`, `useSendTransaction`, `useSignMessage`). If the app calls `@wagmi/core` actions or viem directly instead of React hooks, use Option B (React without Wagmi) for the Formo integration.
 
-  ### **5.2 – NEVER DO THE FOLLOWING**
+  ### **5.2: NEVER DO THE FOLLOWING**
   1. **Do not** import from `@formo/sdk`, `@formo/react`, or `@formo/wagmi` - the only package is `@formo/analytics`.
   2. **Do not** use `useAnalytics()` - the correct hook is `useFormo()`.
   3. **Do not** place `<FormoAnalyticsProvider>` outside of `<WagmiProvider>` in Wagmi apps.
@@ -227,7 +227,7 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
   5. **Do not** use `useFormo()` in Next.js Server Components - it only works in Client Components.
   6. **Do not** mix App Router (`app/layout.tsx`) and Pages Router (`pages/_app.tsx`) patterns.
 
-  ### **5.3 – OUTDATED PATTERNS TO AVOID**
+  ### **5.3: OUTDATED PATTERNS TO AVOID**
   // ❌ Wrong packages:
   import { FormoAnalytics } from '@formo/sdk'
   import { FormoProvider } from '@formo/react'

--- a/mcp/api-key.mdx
+++ b/mcp/api-key.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'MCP API Key'
+title: 'MCP API key'
 sidebarTitle: 'API Key'
 icon: brackets-curly
 description: 'Connect MCP clients to Formo with a Workspace API Key.'

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'MCP Overview'
+title: 'MCP overview'
 sidebarTitle: 'Overview'
 icon: robot
 description: 'Connect AI agents, coding tools, and your own apps to Formo with MCP.'

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -2,12 +2,12 @@
 title: 'MCP Overview'
 sidebarTitle: 'Overview'
 icon: robot
-description: 'Connect AI agents, coding tools, and custom workflows to Formo with MCP.'
+description: 'Connect AI agents, coding tools, and your own apps to Formo with MCP.'
 ---
 
 ## Overview
 
-The Formo MCP Server enables AI tools, OAuth-capable clients, editor integrations, and custom workflows to query your analytics data directly. Ask questions about your users, events, and metrics in natural language.
+The Formo MCP Server lets AI assistants, code editors, and custom integrations query your analytics data directly. Ask questions about your users, events, and metrics in natural language.
 
 The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open standard that allows AI assistants to connect to external data sources and tools. With Formo's MCP server, you can ask:
 


### PR DESCRIPTION
Rework the MCP overview intro to drop protocol jargon ("OAuth-capable clients") and the vague "custom workflows", and align the tagline and overview on one consistent idea of what connects: AI assistants, code editors, and custom integrations.

Replace en dashes with style-guide-compliant punctuation across install, custom-events, key-metrics, and the funnel API reference.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786861710&installation_id=130740768&pr_number=103&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F103&signature=9ff97a639684487dd65e4ec05678ba67eb51bca4e0b45a4d266be6cd9b0f0dba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->