### PR TITLE
MCP: drop the mcp:read scope from the docs

### DIFF
--- a/api/authentication.mdx
+++ b/api/authentication.mdx
@@ -41,7 +41,6 @@ When creating a Workspace API Key, select the scopes your key needs. Each API en
 | `profiles:read` | Search and get wallet profiles | Scale / Enterprise |
 | `profiles:write` | Import wallet addresses (requires profiles:read) | Scale / Enterprise |
 | `query:read` | Execute SQL analytics queries | Scale / Enterprise |
-| `mcp:read` | Deprecated. No longer required; MCP access is granted by the per-resource scopes above. Accepted for backward compatibility | Scale / Enterprise |
 | `alerts:read` | List and get alerts | Scale / Enterprise |
 | `alerts:write` | Create, update, delete alerts (requires alerts:read) | Scale / Enterprise |
 | `boards:read` | List and get boards and charts | Any plan |

--- a/api/authentication.mdx
+++ b/api/authentication.mdx
@@ -41,7 +41,7 @@ When creating a Workspace API Key, select the scopes your key needs. Each API en
 | `profiles:read` | Search and get wallet profiles | Scale / Enterprise |
 | `profiles:write` | Import wallet addresses (requires profiles:read) | Scale / Enterprise |
 | `query:read` | Execute SQL analytics queries | Scale / Enterprise |
-| `mcp:read` | MCP protocol access | Scale / Enterprise |
+| `mcp:read` | Deprecated. No longer required; MCP access is granted by the per-resource scopes above. Accepted for backward compatibility | Scale / Enterprise |
 | `alerts:read` | List and get alerts | Scale / Enterprise |
 | `alerts:write` | Create, update, delete alerts (requires alerts:read) | Scale / Enterprise |
 | `boards:read` | List and get boards and charts | Any plan |
@@ -52,7 +52,7 @@ When creating a Workspace API Key, select the scopes your key needs. Each API en
 | `segments:write` | Create and delete segments (requires segments:read) | Any plan |
 
 <Note>
-  Write scopes automatically require the corresponding read scope. Profiles, Query, MCP, and Alerts scopes require a Scale or Enterprise plan. Create keys with the required scopes in Team Settings &gt; API Keys.
+  Write scopes automatically require the corresponding read scope. Profiles, Query, and Alerts scopes require a Scale or Enterprise plan. Create keys with the required scopes in Team Settings &gt; API Keys.
 </Note>
 
 ## SDK Write Key

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2233,8 +2233,7 @@
       "segments:write": "Create and delete segments (requires segments:read)",
       "profiles:read": "Search and get wallet profiles",
       "profiles:write": "Update wallet properties, manage labels, and import addresses (requires profiles:read)",
-      "query:read": "Execute SQL analytics queries and read pre-built analytics endpoints (KPIs, top pages, lifecycle, retention, revenue, etc.)",
-      "mcp:read": "MCP protocol access (analytics tools + management tools based on other scopes)"
+      "query:read": "Execute SQL analytics queries and read pre-built analytics endpoints (KPIs, top pages, lifecycle, retention, revenue, etc.)"
     }
   },
   "paths": {

--- a/mcp/api-key.mdx
+++ b/mcp/api-key.mdx
@@ -30,7 +30,7 @@ https://api.formo.so/v0/mcp/
 1. Go to your [Formo workspace settings](https://app.formo.so)
 2. Navigate to **Settings** → **API Keys**
 3. Click **Create API Key**
-4. Enable the **MCP** scope
+4. Enable the permissions the AI tool needs. **Query API** read covers analytics and SQL; add **Alerts**, **Charts**, **Contracts** or **Segments** to let it read or manage those.
 5. Copy the generated key
 
 Use the API key as a Bearer token:
@@ -204,9 +204,11 @@ Select your client below to configure Formo with API key authentication.
 
 ## Troubleshooting
 
-**`403 MCP access requires a Scale or Enterprise plan`:** MCP is available only on Scale and Enterprise plans. A valid API key with the MCP scope is not sufficient on a Growth workspace. [Upgrade your workspace](https://app.formo.so) to connect MCP.
+**`403 MCP access requires a Scale or Enterprise plan`:** MCP is available only on Scale and Enterprise plans. A valid API key is not sufficient on a Growth workspace. [Upgrade your workspace](https://app.formo.so) to connect MCP.
 
-**Tools not appearing:** Verify your API key has the MCP scope enabled. Check that the URL ends with a trailing slash: `https://api.formo.so/v0/mcp/`. Restart your AI assistant after configuration changes.
+**Tools not appearing:** Check that the URL ends with a trailing slash: `https://api.formo.so/v0/mcp/`. Restart your AI assistant after configuration changes.
+
+**`insufficient scope` on a tool call:** the key is missing that tool's permission. Analytics and SQL tools need **Query API** read; managing alerts, charts, contracts or segments needs the matching permission. There is no separate MCP scope to enable.
 
 **Authentication errors:** Ensure the API key is sent as `Authorization: Bearer YOUR_API_KEY`. Check that the API key has not been revoked.
 

--- a/mcp/api-key.mdx
+++ b/mcp/api-key.mdx
@@ -30,7 +30,7 @@ https://api.formo.so/v0/mcp/
 1. Go to your [Formo workspace settings](https://app.formo.so)
 2. Navigate to **Settings** → **API Keys**
 3. Click **Create API Key**
-4. Enable the permissions the AI tool needs. **Query API** read covers analytics and SQL; add **Alerts**, **Charts**, **Contracts** or **Segments** to let it read or manage those.
+4. Enable the permissions you need. **Query API** read covers analytics and SQL; add **Alerts**, **Charts**, **Contracts** or **Segments** to let it read or manage those.
 5. Copy the generated key
 
 Use the API key as a Bearer token:

--- a/mcp/oauth.mdx
+++ b/mcp/oauth.mdx
@@ -126,7 +126,7 @@ Select your web client below to configure Formo with OAuth authentication.
     5. Save or connect the server
     6. Sign in to Formo, select a project, and approve access
 
-    If the client asks for scopes, request only `mcp:read` and `offline_access`.
+    If the client asks for scopes, request the permissions you need (for example `query:read`) plus `offline_access` if it needs to refresh.
   </Tab>
 </Tabs>
 
@@ -140,10 +140,16 @@ Formo MCP OAuth supports only these scopes:
 
 | Scope | Description |
 |:------|:------------|
-| `mcp:read` | Read-only MCP access to the selected Formo project |
+| `query:read` | Analytics and SQL tools for the selected project |
+| `alerts:read` / `alerts:write` | Read or manage alerts |
+| `boards:read` / `boards:write` | Read or manage charts and boards |
+| `contracts:read` / `contracts:write` | Read or manage tracked contracts |
+| `segments:read` / `segments:write` | Read or manage segments |
+| `profiles:read` | Wallet profile lookup |
+| `mcp:read` | Deprecated. No longer required; accepted so existing connections keep working |
 | `offline_access` | Allows the MCP client to refresh access without asking the user to sign in again |
 
-Formo does not expose `mcp:tools` or `mcp:resources` scopes. Tool permission decisions are handled by the MCP client.
+Formo does not expose `mcp:tools` or `mcp:resources` scopes. Each tool call is authorised against the granted per-resource scopes above.
 
 OAuth access is bound to the project selected on the Formo consent page. The MCP server validates that the user still has access to that project before serving requests.
 
@@ -180,7 +186,7 @@ The backend accepts either:
 - `Authorization: Bearer <oauth_access_token>`
 - `Authorization: Bearer <workspace_api_key>`
 
-Workspace API keys must include the MCP scope. Existing Claude Desktop, Cursor, Claude Code, Windsurf, VS Code, Codex, and `mcp-remote` configurations do not need to change. For setup instructions, see [MCP API Key](/mcp/api-key).
+Workspace API keys need the permissions the tools you call require. Existing Claude Desktop, Cursor, Claude Code, Windsurf, VS Code, Codex, and `mcp-remote` configurations do not need to change. For setup instructions, see [MCP API Key](/mcp/api-key).
 
 Use a Workspace API Key when your MCP client supports custom request headers and you want to manage credentials yourself, such as local developer tools, CLI bridges, and editor integrations.
 
@@ -190,7 +196,7 @@ Use a Workspace API Key when your MCP client supports custom request headers and
 
 **Client does not start OAuth:** Confirm the MCP server URL is exactly `https://api.formo.so/v0/mcp/` and includes the trailing slash.
 
-**Invalid scope:** Request only `mcp:read` and, when refresh is needed, `offline_access`.
+**Invalid scope:** Request supported scopes only (see the table above), plus `offline_access` when refresh is needed.
 
 **Consent page asks you to sign in again:** Sign in to Formo and you will be returned to the same OAuth authorization flow.
 
@@ -198,4 +204,4 @@ Use a Workspace API Key when your MCP client supports custom request headers and
 
 **Project access denied after connecting:** Reconnect and choose a project that your Formo user can still access.
 
-**API key stopped working:** OAuth does not replace API keys. Check that the key has MCP scope, has not been revoked, and is sent as `Authorization: Bearer <workspace_api_key>`.
+**API key stopped working:** OAuth does not replace API keys. Check that the key has the permission the failing tool needs (analytics and SQL need `query:read`), has not been revoked, and is sent as `Authorization: Bearer <workspace_api_key>`.

--- a/mcp/oauth.mdx
+++ b/mcp/oauth.mdx
@@ -146,7 +146,6 @@ Formo MCP OAuth supports only these scopes:
 | `contracts:read` / `contracts:write` | Read or manage tracked contracts |
 | `segments:read` / `segments:write` | Read or manage segments |
 | `profiles:read` | Wallet profile lookup |
-| `mcp:read` | Deprecated. No longer required; accepted so existing connections keep working |
 | `offline_access` | Allows the MCP client to refresh access without asking the user to sign in again |
 
 Formo does not expose `mcp:tools` or `mcp:resources` scopes. Each tool call is authorised against the granted per-resource scopes above.
@@ -186,7 +185,7 @@ The backend accepts either:
 - `Authorization: Bearer <oauth_access_token>`
 - `Authorization: Bearer <workspace_api_key>`
 
-Workspace API keys need the permissions the tools you call require. Existing Claude Desktop, Cursor, Claude Code, Windsurf, VS Code, Codex, and `mcp-remote` configurations do not need to change. For setup instructions, see [MCP API Key](/mcp/api-key).
+Existing Claude Desktop, Cursor, Claude Code, Windsurf, VS Code, Codex, and `mcp-remote` configurations do not need to change. For setup instructions, see [MCP API Key](/mcp/api-key).
 
 Use a Workspace API Key when your MCP client supports custom request headers and you want to manage credentials yourself, such as local developer tools, CLI bridges, and editor integrations.
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -26,7 +26,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open 
 
 Formo supports two authentication methods for MCP:
 
-- **OAuth** for clients that manage user sign-in. Users sign in to Formo, select a project on the consent page, and approve read-only MCP access.
+- **OAuth** for clients that manage user sign-in. Users sign in to Formo, select a project on the consent page, and choose which permissions to approve.
 - **Workspace API keys** for clients that let you configure an `Authorization` header manually.
 
 <Note>
@@ -102,6 +102,31 @@ The Formo MCP server exposes a curated set of tools, grouped below.
 | `flow` | User journey and path analysis |
 | `search_profile` | Look up enrichment for a single wallet address (net worth, tokens, labels) |
 
+**Management**
+
+These read and change your project's configuration. Each one requires the
+matching permission on your API key (or on the OAuth consent you approved); a
+connection without it is denied with `insufficient scope`.
+
+| Tool | Description | Permission |
+|:-----|:------------|:-----------|
+| `list_alerts`, `get_alert` | Read alerts | `alerts:read` |
+| `create_alert`, `update_alert`, `toggle_alert`, `delete_alert` | Manage alerts | `alerts:write` |
+| `list_contracts`, `get_contract` | Read tracked contracts | `contracts:read` |
+| `create_contract`, `update_contract`, `toggle_contract_pipeline`, `delete_contract` | Manage tracked contracts | `contracts:write` |
+| `list_boards`, `get_board`, `list_charts`, `get_chart` | Read boards and charts | `boards:read` |
+| `create_board`, `update_board`, `delete_board` | Manage boards | `boards:write` |
+| `create_chart`, `update_chart`, `delete_chart`, `duplicate_chart`, `move_chart` | Manage charts | `boards:write` |
+| `list_segments` | Read segments | `segments:read` |
+| `create_segment`, `delete_segment` | Manage segments | `segments:write` |
+| `preview_chart` | Run a chart's SQL without saving | `query:read` |
+
+<Warning>
+  The `delete_*` tools permanently remove data. They will not run unless the
+  call passes `"confirm": true`, so an assistant has to ask you first rather
+  than delete on its own. Grant write permissions only to clients you trust.
+</Warning>
+
 **Docs**
 
 | Tool | Description |
@@ -125,7 +150,7 @@ The Formo MCP server exposes a curated set of tools, grouped below.
     You can query KPIs, traffic sources, top pages, top events, geographic distribution, revenue, lifecycle, retention, frequency, cohorts, funnels, and wallet enrichment. Most of these are available as first-class tools (see [Available tools](#available-tools)).
   </Accordion>
   <Accordion title="Is my analytics data secure when using the MCP Server?">
-    Yes. The MCP Server provides read-only access scoped to one Formo project. OAuth users select the project during consent, and API keys are project-specific. No data is stored by the MCP server itself.
+    Access is scoped to one Formo project and to the permissions you grant. OAuth users select the project and approve permissions on the consent page; API keys are project-specific and carry their own permissions. A connection can only read analytics if it has `query:read`, and can only change alerts, charts, contracts or segments if you granted the matching write permission, so read-only access is what you get unless you opt in. Deletions additionally require an explicit confirmation. No data is stored by the MCP server itself.
   </Accordion>
   <Accordion title="Can I still use an API key?">
     Yes. OAuth is additive. Existing Workspace API Key configurations continue to work with `Authorization: Bearer YOUR_API_KEY`.
@@ -144,4 +169,8 @@ The Formo MCP server exposes a curated set of tools, grouped below.
 
 ### Security
 
-The Formo MCP server provides read-only access to analytics data. OAuth access is scoped to the project selected on the Formo consent page. API key access is scoped to the project attached to the key. MCP sessions expire after 1 hour of inactivity.
+The Formo MCP server is scoped to a single project and to the permissions granted to the connection. OAuth access is scoped to the project selected on the Formo consent page; API key access is scoped to the project attached to the key.
+
+Every tool call is authorised against the granted per-resource permissions, so a connection with only `query:read` can read analytics and nothing else. Tools that change your project require the matching write permission (`alerts:write`, `boards:write`, `contracts:write`, `segments:write`), and tools that delete require an explicit `"confirm": true` on the call.
+
+You can review and change what a connected app is allowed to do, or disconnect it, under **Settings** → **Connected apps**. Disconnecting takes effect on the app's next request. Changing permissions applies when the app reconnects. MCP sessions expire after 1 hour of inactivity.


### PR DESCRIPTION
## Summary

Docs half of getformo/formono#2045, which removes the `mcp:read` connect gate.

`mcp:read` gated the door but granted nothing. Every tool authorises against the per-resource scopes (`query:read`, `alerts:write`, …), so a key could hold `mcp:read` and still be denied by every call. That mismatch produced four dead API keys on the P-2341 deploy. Access is now decided purely by the per-resource scopes.

`mcp:read` remains **accepted**, so existing keys and OAuth connections keep working. It's simply ignored.

## Key Changes

- **`mcp/api-key`** ,  step 4 said "Enable the **MCP** scope", which now grants nothing and isn't even a row in the create dialog. It points at the permissions that actually decide what the agent can do. Adds an `insufficient scope` troubleshooting entry, since that's the error users will actually hit.
- **`mcp/oauth`** ,  the supported-scope table listed *only* `mcp:read`, which was already misleading (per-resource scopes shipped with write support). It now lists the real vocabulary and marks `mcp:read` deprecated.
- **`api/authentication`** ,  same for the API scope table, and drops MCP from the plan-gated scope sentence.

## Also fixed: overview claimed read-only access

`mcp/overview` said the server "provides read-only access to analytics data" in three places, and its tool tables listed **only the read tools**. That stopped being true when getformo/formono#2027 shipped 18 write tools, so a connected agent can create, update and delete alerts, charts, contracts and segments when granted. A security section that understates what a connection can do is worse than none at all.

- Documents the write tools and the management reads that were missing entirely, each with the permission it needs. **Cross-checked against `formoMcpNativeTools.ts`: all 28 native tools present, zero permission mismatches.**
- Warns that `delete_*` is gated behind an explicit `"confirm": true`, so an assistant has to ask before destroying anything.
- Rewrites the two security answers: access is scoped to the project AND to the granted permissions. Read-only is still what you get unless you opt in, which is the accurate version of the old claim.
- Points users at **Settings > Connected apps** to review, change or revoke, with the timing (disconnect applies on the next request; permission edits on reconnect).
- The OAuth bullet no longer says users "approve read-only MCP access".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786878387&installation_id=130740768&pr_number=104&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F104&signature=0b5ed0bfeaf31b4780a58d7eeec348bb2a97d836164c5a38f5b3fa224790db7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

