### PR TITLE
Remove in-development warning from mobile SDK docs

### DIFF
--- a/sdks/mobile.mdx
+++ b/sdks/mobile.mdx
@@ -4,8 +4,6 @@ icon: mobile
 description: 'Track user events in your mobile apps with the Formo React Native SDK. Measure what matters onchain with full device context and wallet event tracking.'
 ---
 
-<Warning>The mobile SDK is still in active development. [Contact support](https://formo.so/support) to get access.</Warning>
-
 The Formo React Native SDK is designed for mobile apps and implements the standard [Events API](/data/events/overview#events-api) with rich mobile context including device information, network status, and app metadata.
 
 ## Installation


### PR DESCRIPTION
## Summary

`@formo/analytics-react-native@1.0.0` is now published to npm, so the mobile SDK page should no longer tell readers it is in active development and gated behind support access.

## Key changes

- **`sdks/mobile.mdx`** — removed the `<Warning>` banner: *"The mobile SDK is still in active development. Contact support to get access."*

## Notes

- The page's technical content is already current — [#110](https://github.com/getformo/docs.formo.so/pull/110) brought session management, the synthesized user agent, `app://` screen paths, and Android install attribution in line with the code. I re-checked the documented options against the published 1.0.0 `src/types/base.ts` and they match.
- Swept the rest of the docs for related stale framing: nav config carries no status badge for mobile, and the `install.mdx` SDK card has none either. The remaining "In development" note in `data/data-sync.mdx` is a different feature and was left alone.
- The removed banner also carried the only "contact support to get access" pointer on this page. Removing it assumes mobile SDK access is no longer gated per workspace — flagging in case that's still true and the sentence should return without the development claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787217441&installation_model_id=21031&pr_number=111&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F111&signature=69ef2e20530f1395f1e0b732e2298ae3c0bc0f56906577a50c38ecd63dd60830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->