### PR TITLE
Post-P-2373: legacy filter-operator spellings are rejected, not accepted

### DIFF
--- a/api/boards/create-chart.mdx
+++ b/api/boards/create-chart.mdx
@@ -160,10 +160,10 @@ Each step in the `steps` array has the following shape:
 <Tip>
   For `in` and `nin`, join multiple values with a pipe `|`. Escape a literal
   pipe with `\|` and a literal backslash with `\\`. The legacy numeric long
-  forms (`greater`, `greaterOrEqual`, `less`, `lessOrEqual`) are deprecated
-  aliases for `gt` / `gte` / `lt` / `lte` and remain accepted. `notEmpty` and
-  `isEmpty` are rejected on the numeric event columns `volume` / `revenue` /
-  `points`.
+  forms (`greater`, `greaterOrEqual`, `less`, `lessOrEqual`) are retired and
+  rejected with a `400` naming the token — send `gt` / `gte` / `lt` / `lte`.
+  `notEmpty` and `isEmpty` are rejected on the numeric event columns `volume` /
+  `revenue` / `points`.
 </Tip>
 
 ### `settings` for Funnel Charts
@@ -573,10 +573,10 @@ Each step in the `steps` array has the following shape:
 <Tip>
   For `in` and `nin`, join multiple values with a pipe `|`. Escape a literal
   pipe with `\|` and a literal backslash with `\\`. The legacy numeric long
-  forms (`greater`, `greaterOrEqual`, `less`, `lessOrEqual`) are deprecated
-  aliases for `gt` / `gte` / `lt` / `lte` and remain accepted. `notEmpty` and
-  `isEmpty` are rejected on the numeric event columns `volume` / `revenue` /
-  `points`.
+  forms (`greater`, `greaterOrEqual`, `less`, `lessOrEqual`) are retired and
+  rejected with a `400` naming the token — send `gt` / `gte` / `lt` / `lte`.
+  `notEmpty` and `isEmpty` are rejected on the numeric event columns `volume` /
+  `revenue` / `points`.
 </Tip>
 
 ### `settings` for Funnel Charts

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -74,11 +74,7 @@
         "properties": {
           "error": {
             "type": "object",
-            "required": [
-              "code",
-              "message",
-              "doc_url"
-            ],
+            "required": ["code", "message", "doc_url"],
             "properties": {
               "code": {
                 "$ref": "#/components/schemas/ErrorCode"
@@ -104,9 +100,7 @@
             }
           }
         },
-        "required": [
-          "error"
-        ]
+        "required": ["error"]
       },
       "ErrorCode": {
         "type": "string",
@@ -147,17 +141,11 @@
           },
           "trigger_type": {
             "type": "string",
-            "enum": [
-              "event",
-              "user"
-            ]
+            "enum": ["event", "user"]
           },
           "status": {
             "type": "string",
-            "enum": [
-              "active",
-              "inactive"
-            ]
+            "enum": ["active", "inactive"]
           },
           "trigger_filters": {
             "type": "array",
@@ -169,7 +157,7 @@
                 },
                 "operator": {
                   "type": "string",
-                  "description": "Comparison operator for the trigger filter. Both the canonical filter operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty`) and their legacy aliases (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`, `like`, `=`, `!=`) are accepted; the value is normalized to canonical form before the alert condition is evaluated."
+                  "description": "Comparison operator for the trigger filter. Only the canonical filter operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty`) are accepted; the retired legacy aliases (`equals`, `greater`, `like`, `=`, …) are rejected with a 400 naming the token."
                 },
                 "value": {
                   "type": "string"
@@ -178,10 +166,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "name",
-                "value"
-              ]
+              "required": ["name", "value"]
             }
           },
           "recipient": {
@@ -191,11 +176,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "email",
-                    "slack",
-                    "webhook"
-                  ]
+                  "enum": ["email", "slack", "webhook"]
                 },
                 "value": {
                   "type": "array",
@@ -204,10 +185,7 @@
                   }
                 }
               },
-              "required": [
-                "type",
-                "value"
-              ]
+              "required": ["type", "value"]
             }
           },
           "project_id": {
@@ -217,13 +195,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "trigger_type",
-          "status",
-          "project_id"
-        ]
+        "required": ["id", "name", "trigger_type", "status", "project_id"]
       },
       "Board": {
         "type": "object",
@@ -255,11 +227,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "id",
-          "project_id",
-          "enabled"
-        ]
+        "required": ["id", "project_id", "enabled"]
       },
       "StepFilterCondition": {
         "type": "object",
@@ -282,7 +250,7 @@
               "notEmpty",
               "isEmpty"
             ],
-            "description": "Comparison operator. The terse comparison tokens (`gt`, `gte`, `lt`, `lte`) are canonical; the legacy long forms (`greater`, `greaterOrEqual`, `less`, `lessOrEqual`) remain accepted and equivalent (deprecated). Use `in` / `nin` for multi-value matching (pipe-delimited value string). `notEmpty` (\"is not empty\") and `isEmpty` (\"is empty\") are value-less existence checks on the property; the `value` is ignored. Existence checks are rejected on the numeric event columns `volume`/`revenue`/`points` — a number has no emptiness semantics."
+            "description": "Comparison operator. Only the canonical terse tokens are accepted (the retired long forms `greater`/`greaterOrEqual`/`less`/`lessOrEqual` are rejected). Use `in` / `nin` for multi-value matching (pipe-delimited value string). `notEmpty` (\"is not empty\") and `isEmpty` (\"is empty\") are value-less existence checks on the property; the `value` is ignored. Existence checks are rejected on the numeric event columns `volume`/`revenue`/`points` — a number has no emptiness semantics."
           },
           "value": {
             "oneOf": [
@@ -296,10 +264,7 @@
             "description": "The comparison value. For `in` / `nin`, use a pipe-delimited string: `\"metamask|rainbow|coinbase\"`."
           }
         },
-        "required": [
-          "op",
-          "value"
-        ]
+        "required": ["op", "value"]
       },
       "FunnelStep": {
         "type": "object",
@@ -307,11 +272,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "event",
-              "track",
-              "decoded_log"
-            ],
+            "enum": ["event", "track", "decoded_log"],
             "description": "`event`: built-in page/connect/transaction events; `track`: custom tracked events; `decoded_log`: decoded smart-contract events."
           },
           "event": {
@@ -320,10 +281,7 @@
             "description": "Event name (e.g. `page`, `connect`, `transaction`, or a custom track event name)."
           }
         },
-        "required": [
-          "type",
-          "event"
-        ],
+        "required": ["type", "event"],
         "additionalProperties": {
           "$ref": "#/components/schemas/StepFilterCondition"
         }
@@ -339,18 +297,11 @@
           },
           "unit": {
             "type": "string",
-            "enum": [
-              "hour",
-              "day",
-              "week"
-            ],
+            "enum": ["hour", "day", "week"],
             "description": "Time unit. `week` = 7 days."
           }
         },
-        "required": [
-          "value",
-          "unit"
-        ]
+        "required": ["value", "unit"]
       },
       "AnalyticsFilterCondition": {
         "type": "object",
@@ -394,11 +345,7 @@
             "description": "Value to compare against. For `in` / `nin`, pass a pipe-delimited string (e.g. `\"chrome|firefox\"`)."
           }
         },
-        "required": [
-          "field",
-          "op",
-          "value"
-        ]
+        "required": ["field", "op", "value"]
       },
       "RetentionUserFilter": {
         "type": "object",
@@ -422,7 +369,7 @@
               "notEmpty",
               "isEmpty"
             ],
-            "description": "Comparison operator. The terse numeric tokens (`gt`, `gte`, `lt`, `lte`) are canonical; the legacy long forms (`greater`, `greaterOrEqual`, `less`, `lessOrEqual`) remain accepted and equivalent (deprecated). `notEmpty` (\"is not empty\") and `isEmpty` (\"is empty\") are value-less existence checks on a string user property; the `value` is ignored. Substring operators (`startsWith` / `endsWith` / `contains`) are not supported on retention user filters."
+            "description": "Comparison operator. Only the canonical terse tokens are accepted (the retired long forms `greater`/`greaterOrEqual`/`less`/`lessOrEqual` are rejected). `notEmpty` (\"is not empty\") and `isEmpty` (\"is empty\") are value-less existence checks on a string user property; the `value` is ignored. Substring operators (`startsWith` / `endsWith` / `contains`) are not supported on retention user filters."
           },
           "value": {
             "oneOf": [
@@ -436,11 +383,7 @@
             "description": "The value to compare against."
           }
         },
-        "required": [
-          "field",
-          "op",
-          "value"
-        ]
+        "required": ["field", "op", "value"]
       },
       "RetentionLabelSignal": {
         "type": "object",
@@ -452,13 +395,7 @@
           },
           "op": {
             "type": "string",
-            "enum": [
-              "gt",
-              "gte",
-              "lt",
-              "lte",
-              "eq"
-            ],
+            "enum": ["gt", "gte", "lt", "lte", "eq"],
             "default": "gt",
             "description": "Comparison operator. Numeric operators coerce both sides via toFloat64OrZero, so a numeric op on a non-numeric value yields no match (not an error)."
           },
@@ -472,11 +409,7 @@
             "description": "Optional chain scope. Empty string matches across all chains."
           }
         },
-        "required": [
-          "tag_id",
-          "op",
-          "value"
-        ]
+        "required": ["tag_id", "op", "value"]
       },
       "ChartSettings": {
         "type": "object",
@@ -484,10 +417,7 @@
         "properties": {
           "funnelType": {
             "type": "string",
-            "enum": [
-              "closed",
-              "open"
-            ],
+            "enum": ["closed", "open"],
             "default": "closed",
             "description": "**Funnel only.** `closed`: users must complete steps in strict order with no intervening events. `open`: users may complete steps in order but other events may occur between steps."
           },
@@ -566,10 +496,7 @@
           },
           "retentionSignalType": {
             "type": "string",
-            "enum": [
-              "event",
-              "label"
-            ],
+            "enum": ["event", "label"],
             "default": "event",
             "description": "**retention.** `event` (default): cohort and retention are driven by events. `label`: driven by a label value over time (see `retentionLabelSignal`); when `label`, the event fields are ignored."
           },
@@ -644,11 +571,7 @@
             "$ref": "#/components/schemas/ChartSettings"
           }
         },
-        "required": [
-          "projectId",
-          "chart_type",
-          "title"
-        ]
+        "required": ["projectId", "chart_type", "title"]
       },
       "UpdateChartRequest": {
         "type": "object",
@@ -719,12 +642,7 @@
             "$ref": "#/components/schemas/ChartSettings"
           }
         },
-        "required": [
-          "chartId",
-          "projectId",
-          "chart_type",
-          "title"
-        ]
+        "required": ["chartId", "projectId", "chart_type", "title"]
       },
       "Chart": {
         "type": "object",
@@ -852,22 +770,11 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "anonymous",
-                "inputs",
-                "name",
-                "type"
-              ]
+              "required": ["anonymous", "inputs", "name", "type"]
             }
           }
         },
-        "required": [
-          "name",
-          "chain",
-          "address",
-          "abi",
-          "events"
-        ]
+        "required": ["name", "chain", "address", "abi", "events"]
       },
       "Segment": {
         "type": "object",
@@ -888,10 +795,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "title"
-        ]
+        "required": ["id", "title"]
       },
       "Profile": {
         "type": "object",
@@ -1237,11 +1141,7 @@
           },
           "device": {
             "type": "string",
-            "enum": [
-              "desktop",
-              "mobile",
-              "tablet"
-            ]
+            "enum": ["desktop", "mobile", "tablet"]
           },
           "os": {
             "type": "string"
@@ -1284,12 +1184,7 @@
       "Event": {
         "type": "object",
         "description": "A single analytics event",
-        "required": [
-          "type",
-          "anonymous_id",
-          "version",
-          "channel"
-        ],
+        "required": ["type", "anonymous_id", "version", "channel"],
         "properties": {
           "type": {
             "type": "string",
@@ -1308,13 +1203,7 @@
           },
           "channel": {
             "type": "string",
-            "enum": [
-              "web",
-              "mobile",
-              "server",
-              "api",
-              "import"
-            ],
+            "enum": ["web", "mobile", "server", "api", "import"],
             "description": "Source of the event. The Formo Web SDK uses `web`; mobile SDK uses `mobile`; server SDK uses `server`. Use `api` for direct HTTP submissions and `import` for backfills."
           },
           "version": {
@@ -1462,9 +1351,7 @@
       },
       "UserLabelInput": {
         "type": "object",
-        "required": [
-          "tag_id"
-        ],
+        "required": ["tag_id"],
         "properties": {
           "tag_id": {
             "type": "string",
@@ -1485,10 +1372,7 @@
           },
           "_is_deleted": {
             "type": "integer",
-            "enum": [
-              0,
-              1
-            ],
+            "enum": [0, 1],
             "description": "Optional tombstone flag for backfilled removals. `1` records the row as a soft-delete (label removed) instead of a live value; pair it with a past `timestamp` to express \"label removed at past time T\" so point-in-time retention drops the wallet from that week. The future-timestamp guard still applies. Defaults to `0` (a live label) when omitted."
           }
         }
@@ -1535,10 +1419,7 @@
       "UpdateUserPropertiesResponse": {
         "type": "object",
         "description": "Echo of the wallet identity after the merge-update applied. Synthesised from the request payload; analytics ingestion is eventually consistent, so the response reflects the applied write rather than a follow-up read.",
-        "required": [
-          "address",
-          "updated_at"
-        ],
+        "required": ["address", "updated_at"],
         "properties": {
           "address": {
             "type": "string"
@@ -1547,37 +1428,100 @@
             "type": "string",
             "format": "date-time"
           },
-          "user_id": { "type": "string", "nullable": true },
-          "display_name": { "type": "string", "nullable": true },
-          "email": { "type": "string", "nullable": true },
-          "farcaster": { "type": "string", "nullable": true },
-          "discord": { "type": "string", "nullable": true },
-          "twitter": { "type": "string", "nullable": true },
-          "telegram": { "type": "string", "nullable": true },
-          "instagram": { "type": "string", "nullable": true },
-          "website": { "type": "string", "nullable": true },
-          "github": { "type": "string", "nullable": true },
-          "linkedin": { "type": "string", "nullable": true },
-          "facebook": { "type": "string", "nullable": true },
-          "tiktok": { "type": "string", "nullable": true },
-          "youtube": { "type": "string", "nullable": true },
-          "reddit": { "type": "string", "nullable": true },
-          "avatar": { "type": "string", "nullable": true },
-          "description": { "type": "string", "nullable": true },
-          "location": { "type": "string", "nullable": true },
-          "ens": { "type": "string", "nullable": true },
-          "lens": { "type": "string", "nullable": true },
-          "basenames": { "type": "string", "nullable": true },
-          "linea": { "type": "string", "nullable": true }
+          "user_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "display_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "farcaster": {
+            "type": "string",
+            "nullable": true
+          },
+          "discord": {
+            "type": "string",
+            "nullable": true
+          },
+          "twitter": {
+            "type": "string",
+            "nullable": true
+          },
+          "telegram": {
+            "type": "string",
+            "nullable": true
+          },
+          "instagram": {
+            "type": "string",
+            "nullable": true
+          },
+          "website": {
+            "type": "string",
+            "nullable": true
+          },
+          "github": {
+            "type": "string",
+            "nullable": true
+          },
+          "linkedin": {
+            "type": "string",
+            "nullable": true
+          },
+          "facebook": {
+            "type": "string",
+            "nullable": true
+          },
+          "tiktok": {
+            "type": "string",
+            "nullable": true
+          },
+          "youtube": {
+            "type": "string",
+            "nullable": true
+          },
+          "reddit": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "location": {
+            "type": "string",
+            "nullable": true
+          },
+          "ens": {
+            "type": "string",
+            "nullable": true
+          },
+          "lens": {
+            "type": "string",
+            "nullable": true
+          },
+          "basenames": {
+            "type": "string",
+            "nullable": true
+          },
+          "linea": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "BatchWriteResponse": {
         "type": "object",
         "description": "Acknowledgement for a batch write. `successful_rows` counts rows accepted and forwarded to ingest after a 2xx (ingestion is async/eventually-consistent; there is no follow-up read). `quarantined_rows` counts rows skipped for an invalid address or no valid keys; `errors` (omitted when nothing was quarantined) maps each skipped row back to its request index.",
-        "required": [
-          "successful_rows",
-          "quarantined_rows"
-        ],
+        "required": ["successful_rows", "quarantined_rows"],
         "properties": {
           "successful_rows": {
             "type": "integer",
@@ -1623,20 +1567,14 @@
           },
           "logic": {
             "type": "string",
-            "enum": [
-              "and",
-              "or"
-            ],
+            "enum": ["and", "or"],
             "default": "and"
           }
         }
       },
       "FilterCondition": {
         "type": "object",
-        "required": [
-          "field",
-          "op"
-        ],
+        "required": ["field", "op"],
         "properties": {
           "field": {
             "type": "string",
@@ -1655,27 +1593,16 @@
               "nin",
               "contains",
               "notEmpty",
-              "isEmpty",
-              "equals",
-              "notEquals",
-              "greater",
-              "greaterOrEqual",
-              "less",
-              "lessOrEqual",
-              "notIn",
-              "includes"
+              "isEmpty"
             ],
-            "description": "Comparison operator. The terse tokens (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `notEmpty`, `isEmpty`) are canonical; the long-form spellings (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`) are deprecated aliases that remain accepted and are folded to canonical at the boundary. `contains` (case-insensitive substring) is only supported on social fields (e.g. `users.twitter`, `users.email`). `notEmpty` (\"is not empty\" / \"is set\") is a string existence check for user string attributes (device/os/utm_*/referrer/…) and social fields; `isEmpty` (\"is empty\" / \"is not set\") is its complement, supported for user string attributes only (not social fields). Both ignore `value`. `users.lifecycle` supports only `eq` (a single stage) and `in` (a list of stages)."
+            "description": "Comparison operator. Only the canonical terse tokens (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `notEmpty`, `isEmpty`) are accepted; the retired long-form spellings (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`) are rejected with a 400 naming the token. `contains` (case-insensitive substring) is only supported on social fields (e.g. `users.twitter`, `users.email`). `notEmpty` (\"is not empty\" / \"is set\") is a string existence check for user string attributes (device/os/utm_*/referrer/…) and social fields; `isEmpty` (\"is empty\" / \"is not set\") is its complement, supported for user string attributes only (not social fields). Both ignore `value`. `users.lifecycle` supports only `eq` (a single stage) and `in` (a list of stages)."
           },
           "value": {
             "description": "Filter value (string, number, boolean, or array). Required for every operator except the existence checks `notEmpty` and `isEmpty`, which ignore it."
           },
           "scope": {
             "type": "string",
-            "enum": [
-              "any",
-              "protocol"
-            ],
+            "enum": ["any", "protocol"],
             "description": "For token filters: any=wallet+protocol, protocol=specific app"
           },
           "appId": {
@@ -1854,43 +1781,71 @@
       "LifecycleNewWindowDays": {
         "name": "new_window_days",
         "in": "query",
-        "schema": { "type": "integer", "minimum": 1, "maximum": 90 },
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 90
+        },
         "description": "Override: a wallet is New if first seen within this many days of the reference date (default 30). Caller value wins over the project's saved setting."
       },
       "LifecycleChurnWindowDays": {
         "name": "churn_window_days",
         "in": "query",
-        "schema": { "type": "integer", "minimum": 1, "maximum": 90 },
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 90
+        },
         "description": "Override: a wallet is Churned once last seen this many days before the reference date (default 30)."
       },
       "LifecyclePowerUserMinActiveDays": {
         "name": "power_user_min_active_days",
         "in": "query",
-        "schema": { "type": "integer", "minimum": 1, "maximum": 90 },
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 90
+        },
         "description": "Override: distinct active days within the power-user window required to qualify as Power user (default 5)."
       },
       "LifecyclePowerUserWindowDays": {
         "name": "power_user_window_days",
         "in": "query",
-        "schema": { "type": "integer", "minimum": 1, "maximum": 90 },
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 90
+        },
         "description": "Override: trailing window in which active days are counted for Power user qualification (default 30)."
       },
       "LifecycleResurrectedGapDays": {
         "name": "resurrected_gap_days",
         "in": "query",
-        "schema": { "type": "integer", "minimum": 1, "maximum": 90 },
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 90
+        },
         "description": "Override: minimum inactivity gap that marks a re-engaging wallet as Resurrected (default 30)."
       },
       "LifecycleAtRiskMinDaysInactive": {
         "name": "at_risk_min_days_inactive",
         "in": "query",
-        "schema": { "type": "integer", "minimum": 1, "maximum": 90 },
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 90
+        },
         "description": "Override: minimum days since last activity for an established, still-active wallet to be At Risk (default 14; must be < churn_window_days)."
       },
       "LifecycleAtRiskPriorActiveDaysThreshold": {
         "name": "at_risk_prior_active_days_threshold",
         "in": "query",
-        "schema": { "type": "integer", "minimum": 1, "maximum": 90 },
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 90
+        },
         "description": "Override: minimum active days a wallet had in the window before the recent quiet stretch to qualify as At Risk (default 1)."
       },
       "AnalyticsProfileFilters": {
@@ -1927,10 +1882,7 @@
                 "type": "string"
               }
             },
-            "example": [
-              "ens",
-              "farcaster"
-            ]
+            "example": ["ens", "farcaster"]
           }
         }
       },
@@ -1946,15 +1898,7 @@
                 "type": "array"
               }
             },
-            "example": [
-              [
-                "protocol",
-                1,
-                "uniswap-v3",
-                "gt",
-                "0"
-              ]
-            ]
+            "example": [["protocol", 1, "uniswap-v3", "gt", "0"]]
           }
         }
       },
@@ -1995,13 +1939,7 @@
                 "type": "array"
               }
             },
-            "example": [
-              [
-                1,
-                "gt",
-                "0"
-              ]
-            ]
+            "example": [[1, "gt", "0"]]
           }
         }
       },
@@ -2024,7 +1962,10 @@
                 "op": "gte",
                 "times": 1,
                 "relative_to": "first_seen",
-                "window": { "value": 24, "unit": "hour" }
+                "window": {
+                  "value": 24,
+                  "unit": "hour"
+                }
               }
             ]
           }
@@ -2074,14 +2015,7 @@
                 "type": "array"
               }
             },
-            "example": [
-              [
-                "whale",
-                1,
-                "eq",
-                "true"
-              ]
-            ]
+            "example": [["whale", 1, "eq", "true"]]
           }
         }
       },
@@ -2257,13 +2191,15 @@
         "operationId": "listAlerts",
         "summary": "List alerts",
         "description": "List alerts for the project scoped to the API key. Paginated: see `page` and `size` query params; the response carries `total` and `has_more` so callers can walk pages.",
-        "tags": [
-          "Alerts"
-        ],
+        "tags": ["Alerts"],
         "x-required-scope": "alerts:read",
         "parameters": [
-          { "$ref": "#/components/parameters/Page" },
-          { "$ref": "#/components/parameters/Size" }
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/Size"
+          }
         ],
         "responses": {
           "200": {
@@ -2272,14 +2208,18 @@
               "application/json": {
                 "schema": {
                   "allOf": [
-                    { "$ref": "#/components/schemas/PaginatedListMeta" },
+                    {
+                      "$ref": "#/components/schemas/PaginatedListMeta"
+                    },
                     {
                       "type": "object",
                       "required": ["data"],
                       "properties": {
                         "data": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Alert" }
+                          "items": {
+                            "$ref": "#/components/schemas/Alert"
+                          }
                         }
                       }
                     }
@@ -2335,9 +2275,7 @@
         "operationId": "createAlert",
         "summary": "Create alert",
         "description": "Create a new alert for the project.",
-        "tags": [
-          "Alerts"
-        ],
+        "tags": ["Alerts"],
         "x-required-scope": "alerts:write",
         "requestBody": {
           "required": true,
@@ -2352,10 +2290,7 @@
                   },
                   "trigger_type": {
                     "type": "string",
-                    "enum": [
-                      "event",
-                      "user"
-                    ]
+                    "enum": ["event", "user"]
                   },
                   "trigger_filters": {
                     "type": "array",
@@ -2367,7 +2302,7 @@
                         },
                         "operator": {
                           "type": "string",
-                          "description": "Comparison operator for the trigger filter. Both the canonical filter operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty`) and their legacy aliases (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`, `like`, `=`, `!=`) are accepted; the value is normalized to canonical form before the alert condition is evaluated."
+                          "description": "Comparison operator for the trigger filter. Only the canonical filter operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty`) are accepted; the retired legacy aliases (`equals`, `greater`, `like`, `=`, …) are rejected with a 400 naming the token."
                         },
                         "value": {
                           "type": "string"
@@ -2376,10 +2311,7 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name",
-                        "value"
-                      ]
+                      "required": ["name", "value"]
                     }
                   },
                   "recipient": {
@@ -2389,11 +2321,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "email",
-                            "slack",
-                            "webhook"
-                          ]
+                          "enum": ["email", "slack", "webhook"]
                         },
                         "value": {
                           "type": "array",
@@ -2409,11 +2337,7 @@
                     "description": "Webhook signing secret"
                   }
                 },
-                "required": [
-                  "name",
-                  "trigger_type",
-                  "trigger_filters"
-                ]
+                "required": ["name", "trigger_type", "trigger_filters"]
               },
               "examples": {
                 "eventAlertWithWebhook": {
@@ -2442,15 +2366,11 @@
                     "recipient": [
                       {
                         "type": "webhook",
-                        "value": [
-                          "https://hooks.myapp.com/formo-alerts"
-                        ]
+                        "value": ["https://hooks.myapp.com/formo-alerts"]
                       },
                       {
                         "type": "email",
-                        "value": [
-                          "alerts@myapp.com"
-                        ]
+                        "value": ["alerts@myapp.com"]
                       }
                     ],
                     "secret": "whsec_mysigningsecret123"
@@ -2508,9 +2428,7 @@
                     "recipient": [
                       {
                         "type": "email",
-                        "value": [
-                          "team@myapp.com"
-                        ]
+                        "value": ["team@myapp.com"]
                       }
                     ]
                   }
@@ -2537,9 +2455,7 @@
                     "recipient": [
                       {
                         "type": "webhook",
-                        "value": [
-                          "https://hooks.myapp.com/token-alerts"
-                        ]
+                        "value": ["https://hooks.myapp.com/token-alerts"]
                       }
                     ]
                   }
@@ -2566,9 +2482,7 @@
       "get": {
         "operationId": "getAlert",
         "summary": "Get alert",
-        "tags": [
-          "Alerts"
-        ],
+        "tags": ["Alerts"],
         "parameters": [
           {
             "name": "alertId",
@@ -2609,15 +2523,11 @@
                   "recipient": [
                     {
                       "type": "email",
-                      "value": [
-                        "alerts@myapp.com"
-                      ]
+                      "value": ["alerts@myapp.com"]
                     },
                     {
                       "type": "slack",
-                      "value": [
-                        "C0123456789"
-                      ]
+                      "value": ["C0123456789"]
                     }
                   ],
                   "has_secret": false,
@@ -2633,9 +2543,7 @@
       "put": {
         "operationId": "updateAlert",
         "summary": "Update alert",
-        "tags": [
-          "Alerts"
-        ],
+        "tags": ["Alerts"],
         "parameters": [
           {
             "name": "alertId",
@@ -2659,10 +2567,7 @@
                   },
                   "trigger_type": {
                     "type": "string",
-                    "enum": [
-                      "event",
-                      "user"
-                    ]
+                    "enum": ["event", "user"]
                   },
                   "trigger_filters": {
                     "type": "array",
@@ -2680,11 +2585,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "name",
-                  "trigger_type",
-                  "trigger_filters"
-                ]
+                "required": ["name", "trigger_type", "trigger_filters"]
               },
               "examples": {
                 "updateRecipients": {
@@ -2705,9 +2606,7 @@
                     "recipient": [
                       {
                         "type": "webhook",
-                        "value": [
-                          "https://hooks.myapp.com/v2/alerts"
-                        ]
+                        "value": ["https://hooks.myapp.com/v2/alerts"]
                       },
                       {
                         "type": "slack",
@@ -2739,9 +2638,7 @@
       "delete": {
         "operationId": "deleteAlert",
         "summary": "Delete alert",
-        "tags": [
-          "Alerts"
-        ],
+        "tags": ["Alerts"],
         "parameters": [
           {
             "name": "alertId",
@@ -2769,9 +2666,7 @@
       "patch": {
         "operationId": "toggleAlertStatus",
         "summary": "Toggle alert status",
-        "tags": [
-          "Alerts"
-        ],
+        "tags": ["Alerts"],
         "parameters": [
           {
             "name": "alertId",
@@ -2791,15 +2686,10 @@
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": [
-                      "active",
-                      "inactive"
-                    ]
+                    "enum": ["active", "inactive"]
                   }
                 },
-                "required": [
-                  "status"
-                ]
+                "required": ["status"]
               },
               "examples": {
                 "activate": {
@@ -2838,12 +2728,14 @@
         "operationId": "listBoards",
         "summary": "List boards",
         "description": "List boards for the project scoped to the API key. Paginated.",
-        "tags": [
-          "Boards"
-        ],
+        "tags": ["Boards"],
         "parameters": [
-          { "$ref": "#/components/parameters/Page" },
-          { "$ref": "#/components/parameters/Size" }
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/Size"
+          }
         ],
         "responses": {
           "200": {
@@ -2852,14 +2744,18 @@
               "application/json": {
                 "schema": {
                   "allOf": [
-                    { "$ref": "#/components/schemas/PaginatedListMeta" },
+                    {
+                      "$ref": "#/components/schemas/PaginatedListMeta"
+                    },
                     {
                       "type": "object",
                       "required": ["data"],
                       "properties": {
                         "data": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Board" }
+                          "items": {
+                            "$ref": "#/components/schemas/Board"
+                          }
                         }
                       }
                     }
@@ -2901,9 +2797,7 @@
         "operationId": "createBoard",
         "summary": "Create board",
         "description": "Create a new board with the given title.",
-        "tags": [
-          "Boards"
-        ],
+        "tags": ["Boards"],
         "requestBody": {
           "required": true,
           "content": {
@@ -2955,9 +2849,7 @@
       "get": {
         "operationId": "getBoard",
         "summary": "Get board",
-        "tags": [
-          "Boards"
-        ],
+        "tags": ["Boards"],
         "parameters": [
           {
             "name": "boardId",
@@ -2994,9 +2886,7 @@
       "patch": {
         "operationId": "updateBoard",
         "summary": "Update board",
-        "tags": [
-          "Boards"
-        ],
+        "tags": ["Boards"],
         "parameters": [
           {
             "name": "boardId",
@@ -3070,9 +2960,7 @@
         "operationId": "deleteBoard",
         "summary": "Delete board",
         "description": "Delete a board and all its charts.",
-        "tags": [
-          "Boards"
-        ],
+        "tags": ["Boards"],
         "parameters": [
           {
             "name": "boardId",
@@ -3103,9 +2991,7 @@
         "operationId": "listCharts",
         "summary": "List charts for a board",
         "description": "List charts in a board with their executed query results. Paginated. Includes the parent `board` for caller convenience and an optional `warnings` sidecar carrying per-chart query failures (the failing charts are excluded from `data` so the page renders cleanly).",
-        "tags": [
-          "Charts"
-        ],
+        "tags": ["Charts"],
         "parameters": [
           {
             "name": "boardId",
@@ -3115,8 +3001,12 @@
               "type": "string"
             }
           },
-          { "$ref": "#/components/parameters/Page" },
-          { "$ref": "#/components/parameters/Size" }
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/Size"
+          }
         ],
         "responses": {
           "200": {
@@ -3125,28 +3015,40 @@
               "application/json": {
                 "schema": {
                   "allOf": [
-                    { "$ref": "#/components/schemas/PaginatedListMeta" },
+                    {
+                      "$ref": "#/components/schemas/PaginatedListMeta"
+                    },
                     {
                       "type": "object",
                       "required": ["data", "board"],
                       "properties": {
                         "data": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Chart" }
+                          "items": {
+                            "$ref": "#/components/schemas/Chart"
+                          }
                         },
-                        "board": { "$ref": "#/components/schemas/Board" },
+                        "board": {
+                          "$ref": "#/components/schemas/Board"
+                        },
                         "warnings": {
                           "type": "object",
                           "description": "Present only if some charts failed to execute. Failures are excluded from `data`.",
                           "properties": {
-                            "failedCharts": { "type": "integer" },
+                            "failedCharts": {
+                              "type": "integer"
+                            },
                             "errors": {
                               "type": "array",
                               "items": {
                                 "type": "object",
                                 "properties": {
-                                  "chartId": { "type": "string" },
-                                  "error": { "type": "string" }
+                                  "chartId": {
+                                    "type": "string"
+                                  },
+                                  "error": {
+                                    "type": "string"
+                                  }
                                 }
                               }
                             }
@@ -3194,9 +3096,7 @@
       "post": {
         "operationId": "createChart",
         "summary": "Create chart",
-        "tags": [
-          "Charts"
-        ],
+        "tags": ["Charts"],
         "parameters": [
           {
             "name": "boardId",
@@ -3361,9 +3261,7 @@
                     "chart_type": "bar",
                     "title": "Daily Active Users",
                     "x_axis": "date",
-                    "y_axis": [
-                      "users"
-                    ]
+                    "y_axis": ["users"]
                   }
                 },
                 "lineChart": {
@@ -3374,9 +3272,7 @@
                     "chart_type": "line",
                     "title": "Daily Active Users",
                     "x_axis": "date",
-                    "y_axis": [
-                      "daily_active_users"
-                    ]
+                    "y_axis": ["daily_active_users"]
                   }
                 },
                 "pieChart": {
@@ -3387,9 +3283,7 @@
                     "chart_type": "pie",
                     "title": "Sessions by Device",
                     "x_axis": "device",
-                    "y_axis": [
-                      "session_count"
-                    ]
+                    "y_axis": ["session_count"]
                   }
                 },
                 "stackedChart": {
@@ -3400,9 +3294,7 @@
                     "chart_type": "stacked",
                     "title": "Sessions by Device and Browser",
                     "x_axis": "device",
-                    "y_axis": [
-                      "session_count"
-                    ],
+                    "y_axis": ["session_count"],
                     "group_by": "browser"
                   }
                 },
@@ -3519,9 +3411,7 @@
       "get": {
         "operationId": "getChart",
         "summary": "Get chart",
-        "tags": [
-          "Charts"
-        ],
+        "tags": ["Charts"],
         "parameters": [
           {
             "name": "boardId",
@@ -3557,9 +3447,7 @@
                   "description": null,
                   "query": "SELECT toDate(timestamp) AS day, sum(revenue) AS revenue FROM events WHERE event = 'transaction' AND timestamp >= now() - INTERVAL 30 DAY GROUP BY day ORDER BY day",
                   "x_axis": "day",
-                  "y_axis": [
-                    "revenue"
-                  ],
+                  "y_axis": ["revenue"],
                   "group_by": null,
                   "steps": null,
                   "settings": null
@@ -3573,9 +3461,7 @@
       "put": {
         "operationId": "editChart",
         "summary": "Edit chart",
-        "tags": [
-          "Charts"
-        ],
+        "tags": ["Charts"],
         "parameters": [
           {
             "name": "boardId",
@@ -3622,9 +3508,7 @@
       "delete": {
         "operationId": "deleteChart",
         "summary": "Delete chart",
-        "tags": [
-          "Charts"
-        ],
+        "tags": ["Charts"],
         "parameters": [
           {
             "name": "boardId",
@@ -3656,12 +3540,14 @@
         "operationId": "listContracts",
         "summary": "List contracts",
         "description": "List monitored contracts. Paginated; the canonical `data` array carries the contracts for the current page. The `deploy` sidecar reports the project-wide deploy state (always reflects ALL contracts, not just this page) so callers can render \"X contracts pending deploy\" without a second request.",
-        "tags": [
-          "Contracts"
-        ],
+        "tags": ["Contracts"],
         "parameters": [
-          { "$ref": "#/components/parameters/Page" },
-          { "$ref": "#/components/parameters/Size" }
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/Size"
+          }
         ],
         "responses": {
           "200": {
@@ -3670,14 +3556,18 @@
               "application/json": {
                 "schema": {
                   "allOf": [
-                    { "$ref": "#/components/schemas/PaginatedListMeta" },
+                    {
+                      "$ref": "#/components/schemas/PaginatedListMeta"
+                    },
                     {
                       "type": "object",
                       "required": ["data", "deploy"],
                       "properties": {
                         "data": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Contract" }
+                          "items": {
+                            "$ref": "#/components/schemas/Contract"
+                          }
                         },
                         "deploy": {
                           "type": "object",
@@ -3786,9 +3676,7 @@
         "operationId": "createContract",
         "summary": "Create contract",
         "description": "Add a blockchain contract to monitor.",
-        "tags": [
-          "Contracts"
-        ],
+        "tags": ["Contracts"],
         "requestBody": {
           "required": true,
           "content": {
@@ -3833,25 +3721,14 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "anonymous",
-                        "inputs",
-                        "name",
-                        "type"
-                      ]
+                      "required": ["anonymous", "inputs", "name", "type"]
                     }
                   },
                   "start_block": {
                     "type": "integer"
                   }
                 },
-                "required": [
-                  "address",
-                  "chain",
-                  "name",
-                  "abi",
-                  "events"
-                ]
+                "required": ["address", "chain", "name", "abi", "events"]
               },
               "examples": {
                 "erc20Token": {
@@ -3915,9 +3792,7 @@
         "operationId": "getContract",
         "summary": "Get contract",
         "description": "Fetch a single monitored contract by chain ID and address. Returns the bare `Contract` resource (no envelope).",
-        "tags": [
-          "Contracts"
-        ],
+        "tags": ["Contracts"],
         "parameters": [
           {
             "name": "chain",
@@ -3951,20 +3826,28 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
         },
         "x-required-scope": "contracts:read"
       },
       "put": {
         "operationId": "updateContract",
         "summary": "Update contract",
-        "tags": [
-          "Contracts"
-        ],
+        "tags": ["Contracts"],
         "parameters": [
           {
             "name": "chain",
@@ -4013,13 +3896,7 @@
                     "type": "integer"
                   }
                 },
-                "required": [
-                  "address",
-                  "chain",
-                  "name",
-                  "abi",
-                  "events"
-                ]
+                "required": ["address", "chain", "name", "abi", "events"]
               }
             }
           }
@@ -4041,9 +3918,7 @@
       "delete": {
         "operationId": "deleteContract",
         "summary": "Delete contract",
-        "tags": [
-          "Contracts"
-        ],
+        "tags": ["Contracts"],
         "parameters": [
           {
             "name": "chain",
@@ -4082,12 +3957,14 @@
         "operationId": "listSegments",
         "summary": "List segments",
         "description": "List user segments for the project scoped to the API key. Paginated.",
-        "tags": [
-          "Segments"
-        ],
+        "tags": ["Segments"],
         "parameters": [
-          { "$ref": "#/components/parameters/Page" },
-          { "$ref": "#/components/parameters/Size" }
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/Size"
+          }
         ],
         "responses": {
           "200": {
@@ -4096,14 +3973,18 @@
               "application/json": {
                 "schema": {
                   "allOf": [
-                    { "$ref": "#/components/schemas/PaginatedListMeta" },
+                    {
+                      "$ref": "#/components/schemas/PaginatedListMeta"
+                    },
                     {
                       "type": "object",
                       "required": ["data"],
                       "properties": {
                         "data": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Segment" }
+                          "items": {
+                            "$ref": "#/components/schemas/Segment"
+                          }
                         }
                       }
                     }
@@ -4117,7 +3998,7 @@
                       "title": "High net worth desktop users",
                       "filterSet": [
                         "{\"field\":\"device\",\"op\":\"eq\",\"value\":\"desktop\"}",
-                        "{\"field\":\"net_worth_usd\",\"op\":\"greaterOrEqual\",\"value\":100000}"
+                        "{\"field\":\"net_worth_usd\",\"op\":\"gte\",\"value\":100000}"
                       ]
                     }
                   ],
@@ -4135,9 +4016,7 @@
       "post": {
         "operationId": "createSegment",
         "summary": "Create segment",
-        "tags": [
-          "Segments"
-        ],
+        "tags": ["Segments"],
         "requestBody": {
           "required": true,
           "content": {
@@ -4157,10 +4036,7 @@
                     "minItems": 1
                   }
                 },
-                "required": [
-                  "title",
-                  "filterSets"
-                ]
+                "required": ["title", "filterSets"]
               },
               "examples": {
                 "highValueMobileUsers": {
@@ -4178,18 +4054,14 @@
                   "summary": "Chrome or Safari users (multi-value filter)",
                   "value": {
                     "title": "Chrome/Safari users",
-                    "filterSets": [
-                      "browser::in::Chrome|Safari"
-                    ]
+                    "filterSets": ["browser::in::Chrome|Safari"]
                   }
                 },
                 "excludeUSUsers": {
                   "summary": "All users except from the US",
                   "value": {
                     "title": "Non-US users",
-                    "filterSets": [
-                      "location::neq::US"
-                    ]
+                    "filterSets": ["location::neq::US"]
                   }
                 },
                 "powerUsers": {
@@ -4269,9 +4141,7 @@
       "delete": {
         "operationId": "deleteSegment",
         "summary": "Delete segment",
-        "tags": [
-          "Segments"
-        ],
+        "tags": ["Segments"],
         "parameters": [
           {
             "name": "segmentId",
@@ -4302,9 +4172,7 @@
         "operationId": "getProfile",
         "summary": "Get wallet profile",
         "description": "Get a single wallet profile. Agents can call the same path through the paid x402 or MPP gateway hosts without a caller-supplied Formo API key; Paysponge uses Formo's workspace API key behind the scenes. Paid gateway callers only provide the protocol payment header returned by the gateway challenge.",
-        "tags": [
-          "Profiles"
-        ],
+        "tags": ["Profiles"],
         "servers": [
           {
             "url": "https://api.formo.so",
@@ -4522,7 +4390,9 @@
             "description": "Wallet not yet profiled. Returned for a first-time lookup while the profile is still being built; retry after the given delay.",
             "headers": {
               "Retry-After": {
-                "schema": { "type": "integer" },
+                "schema": {
+                  "type": "integer"
+                },
                 "description": "Seconds to wait before retrying."
               }
             },
@@ -4531,13 +4401,28 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": { "type": "string", "enum": ["processing"] },
-                    "address": { "type": "string" },
-                    "message": { "type": "string" },
-                    "retry_after": { "type": "integer", "description": "Seconds to wait before retrying." }
+                    "status": {
+                      "type": "string",
+                      "enum": ["processing"]
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "retry_after": {
+                      "type": "integer",
+                      "description": "Seconds to wait before retrying."
+                    }
                   }
                 },
-                "example": { "status": "processing", "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "message": "Wallet profile is being generated. Retry shortly.", "retry_after": 3 }
+                "example": {
+                  "status": "processing",
+                  "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                  "message": "Wallet profile is being generated. Retry shortly.",
+                  "retry_after": 3
+                }
               }
             }
           },
@@ -4559,9 +4444,7 @@
       "get": {
         "operationId": "searchProfiles",
         "summary": "Search wallet profiles",
-        "tags": [
-          "Profiles"
-        ],
+        "tags": ["Profiles"],
         "responses": {
           "200": {
             "description": "Paginated wallet profile search results.",
@@ -4569,14 +4452,18 @@
               "application/json": {
                 "schema": {
                   "allOf": [
-                    { "$ref": "#/components/schemas/PaginatedListMeta" },
+                    {
+                      "$ref": "#/components/schemas/PaginatedListMeta"
+                    },
                     {
                       "type": "object",
                       "required": ["data"],
                       "properties": {
                         "data": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Profile" }
+                          "items": {
+                            "$ref": "#/components/schemas/Profile"
+                          }
                         }
                       }
                     }
@@ -4657,10 +4544,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             },
             "description": "Sort direction"
           },
@@ -4759,9 +4643,7 @@
         "operationId": "updateUserProperties",
         "summary": "Update user properties",
         "description": "Set first-party properties for a wallet profile. Override display name, email, socials, avatar, location, and other identity fields.",
-        "tags": [
-          "Profiles"
-        ],
+        "tags": ["Profiles"],
         "parameters": [
           {
             "name": "address",
@@ -4875,12 +4757,24 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
         },
         "x-required-scope": "profiles:write"
       }
@@ -4890,9 +4784,7 @@
         "operationId": "batchUpdateUserProperties",
         "summary": "Batch update user properties",
         "description": "Set first-party properties for up to 100 wallets in one request. Each item is a flat object with a required `address` (literal EVM `0x...` or Solana; ENS names are NOT resolved here) plus any of the allowed profile keys. Unknown keys are ignored; a row left with no valid keys, or with an invalid address, is quarantined (skipped and reported) rather than failing the batch. A request where every row is invalid returns 400. Requires profiles:write scope.",
-        "tags": [
-          "Profiles"
-        ],
+        "tags": ["Profiles"],
         "requestBody": {
           "required": true,
           "content": {
@@ -4911,28 +4803,72 @@
                       "type": "string",
                       "description": "Wallet address. Literal EVM (0x...) or Solana address only; ENS names are not resolved in batch requests."
                     },
-                    "user_id": { "type": "string" },
-                    "display_name": { "type": "string" },
-                    "email": { "type": "string" },
-                    "farcaster": { "type": "string" },
-                    "discord": { "type": "string" },
-                    "twitter": { "type": "string" },
-                    "telegram": { "type": "string" },
-                    "instagram": { "type": "string" },
-                    "website": { "type": "string" },
-                    "github": { "type": "string" },
-                    "linkedin": { "type": "string" },
-                    "facebook": { "type": "string" },
-                    "tiktok": { "type": "string" },
-                    "youtube": { "type": "string" },
-                    "reddit": { "type": "string" },
-                    "avatar": { "type": "string" },
-                    "description": { "type": "string" },
-                    "location": { "type": "string" },
-                    "ens": { "type": "string" },
-                    "lens": { "type": "string" },
-                    "basenames": { "type": "string" },
-                    "linea": { "type": "string" }
+                    "user_id": {
+                      "type": "string"
+                    },
+                    "display_name": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "farcaster": {
+                      "type": "string"
+                    },
+                    "discord": {
+                      "type": "string"
+                    },
+                    "twitter": {
+                      "type": "string"
+                    },
+                    "telegram": {
+                      "type": "string"
+                    },
+                    "instagram": {
+                      "type": "string"
+                    },
+                    "website": {
+                      "type": "string"
+                    },
+                    "github": {
+                      "type": "string"
+                    },
+                    "linkedin": {
+                      "type": "string"
+                    },
+                    "facebook": {
+                      "type": "string"
+                    },
+                    "tiktok": {
+                      "type": "string"
+                    },
+                    "youtube": {
+                      "type": "string"
+                    },
+                    "reddit": {
+                      "type": "string"
+                    },
+                    "avatar": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "ens": {
+                      "type": "string"
+                    },
+                    "lens": {
+                      "type": "string"
+                    },
+                    "basenames": {
+                      "type": "string"
+                    },
+                    "linea": {
+                      "type": "string"
+                    }
                   }
                 }
               },
@@ -4966,12 +4902,24 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
         },
         "x-required-scope": "profiles:write"
       }
@@ -4981,9 +4929,7 @@
         "operationId": "upsertUserLabel",
         "summary": "Add or update user labels",
         "description": "Upsert one or more labels for a wallet. Accepts either a single label object or an array of labels. Labels with the same tag_id (and chain_id, if provided) are overwritten. Requires profiles:write scope.",
-        "tags": [
-          "Profiles"
-        ],
+        "tags": ["Profiles"],
         "parameters": [
           {
             "name": "address",
@@ -5064,22 +5010,38 @@
               "application/json": {
                 "schema": {
                   "oneOf": [
-                    { "$ref": "#/components/schemas/UserLabel" },
+                    {
+                      "$ref": "#/components/schemas/UserLabel"
+                    },
                     {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/UserLabel" }
+                      "items": {
+                        "$ref": "#/components/schemas/UserLabel"
+                      }
                     }
                   ]
                 }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
         },
         "x-required-scope": "profiles:write"
       },
@@ -5087,9 +5049,7 @@
         "operationId": "deleteUserLabel",
         "summary": "Delete a user label",
         "description": "Delete a label from a wallet. Pass chain_id to scope the deletion to a specific chain; omit it to match labels without a chain scope. Requires profiles:write scope.",
-        "tags": [
-          "Profiles"
-        ],
+        "tags": ["Profiles"],
         "parameters": [
           {
             "name": "address",
@@ -5107,9 +5067,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "tag_id"
-                ],
+                "required": ["tag_id"],
                 "properties": {
                   "tag_id": {
                     "type": "string",
@@ -5136,12 +5094,24 @@
           "204": {
             "description": "Label deleted. No body; the caller already knows the new state."
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
         },
         "x-required-scope": "profiles:write"
       }
@@ -5151,9 +5121,7 @@
         "operationId": "batchUpsertUserLabels",
         "summary": "Batch add or update user labels",
         "description": "Upsert up to 100 labels across many wallets in one request; each item carries its own `address`. Modelled on the events ingest API: rows with an invalid address (ENS names are NOT resolved here; pass a literal EVM `0x...` or Solana address) are quarantined (skipped and reported in the response) rather than failing the whole batch. A request where every row is invalid returns 400. Requires profiles:write scope.",
-        "tags": [
-          "Profiles"
-        ],
+        "tags": ["Profiles"],
         "requestBody": {
           "required": true,
           "content": {
@@ -5164,7 +5132,9 @@
                 "maxItems": 100,
                 "items": {
                   "allOf": [
-                    { "$ref": "#/components/schemas/UserLabelInput" },
+                    {
+                      "$ref": "#/components/schemas/UserLabelInput"
+                    },
                     {
                       "type": "object",
                       "required": ["address"],
@@ -5233,12 +5203,24 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
         },
         "x-required-scope": "profiles:write"
       }
@@ -5248,9 +5230,7 @@
         "operationId": "importWallets",
         "summary": "Import wallet addresses",
         "description": "Import wallet addresses into the project. Requires profiles:write scope and Scale/Enterprise plan.",
-        "tags": [
-          "Profiles"
-        ],
+        "tags": ["Profiles"],
         "requestBody": {
           "required": true,
           "content": {
@@ -5270,10 +5250,7 @@
                     "description": "SDK write key"
                   }
                 },
-                "required": [
-                  "addresses",
-                  "writeKey"
-                ]
+                "required": ["addresses", "writeKey"]
               },
               "examples": {
                 "importWallets": {
@@ -5303,9 +5280,7 @@
         "operationId": "executeQuery",
         "summary": "Execute SQL query",
         "description": "Execute a SQL query against the project's analytics data. Only SELECT and WITH statements are allowed. LIMIT is capped at 1,000,000. Forbidden keywords: INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE, CREATE, etc.",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "requestBody": {
           "required": true,
           "content": {
@@ -5318,9 +5293,7 @@
                     "description": "SQL query to execute"
                   }
                 },
-                "required": [
-                  "query"
-                ]
+                "required": ["query"]
               },
               "examples": {
                 "dailyActiveUsers": {
@@ -5346,13 +5319,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "data",
-                    "total",
-                    "limit",
-                    "offset",
-                    "has_more"
-                  ],
+                  "required": ["data", "total", "limit", "offset", "has_more"],
                   "properties": {
                     "data": {
                       "type": "array",
@@ -5426,9 +5393,7 @@
         "operationId": "getAnalyticsKpis",
         "summary": "Get KPIs (sessions, pageviews, bounce rate, session duration)",
         "description": "Time-series traffic KPIs with optional dimension breakdown. Returns `sessions` (session count), pageviews, bounce rate and average session length. When `include_previous_period=true` without `group_by`, the response also includes `visitors` (unique visitors), `visitors_current` and `visitors_previous`.",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -5574,9 +5539,7 @@
         "operationId": "getAnalyticsTopPages",
         "summary": "Get top pages by sessions or visitors, optionally restricted to entry or exit pages",
         "description": "Returns the most visited pages with traffic metrics. Pass `mode=entry` to restrict to the first page of each session (with `bounce_rate`) or `mode=exit` for the last page (with `exit_rate`). Default `mode=all` returns project-wide page metrics with anon-per-session visitor counts.",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -5699,9 +5662,7 @@
       "get": {
         "operationId": "getAnalyticsTopSources",
         "summary": "Get top traffic sources (referrers / utm)",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -5837,9 +5798,7 @@
       "get": {
         "operationId": "getAnalyticsTopLocations",
         "summary": "Get top countries",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -5952,9 +5911,7 @@
       "get": {
         "operationId": "getAnalyticsTopWallets",
         "summary": "Get top wallet types",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -6059,9 +6016,7 @@
       "get": {
         "operationId": "getAnalyticsTopChains",
         "summary": "Get top blockchain chains",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -6166,9 +6121,7 @@
       "get": {
         "operationId": "getAnalyticsTopEvents",
         "summary": "Get top events by frequency",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -6191,9 +6144,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "custom"
-              ]
+              "enum": ["custom"]
             },
             "description": "Pass 'custom' to filter to custom track events only (events with type='track' and a non-empty event name). Omit for all events."
           }
@@ -6291,9 +6242,7 @@
       "get": {
         "operationId": "getAnalyticsRevenueByMetric",
         "summary": "Get revenue grouped by a chosen column",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -6416,9 +6365,7 @@
       "get": {
         "operationId": "getAnalyticsVolumeByMetric",
         "summary": "Get transaction volume grouped by a chosen column",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -6541,9 +6488,7 @@
       "get": {
         "operationId": "getAnalyticsRevenueOverview",
         "summary": "Get revenue and transaction volume time-series",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -6666,9 +6611,7 @@
         "operationId": "getAnalyticsRevenueTimeseries",
         "summary": "Get per-event revenue and volume trend for a single wallet",
         "description": "Returns daily per-event revenue and volume rows for the given wallet `address`. Scoped per wallet; there is no project-wide aggregate mode on this endpoint.",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -6792,9 +6735,7 @@
       "get": {
         "operationId": "getAnalyticsEventTimeseries",
         "summary": "Get event count time-series",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -6912,9 +6853,7 @@
         "operationId": "getAnalyticsLifecycle",
         "summary": "Get user lifecycle stages (New / Returning / Power user / Resurrected / At Risk / Churned)",
         "description": "Counts wallet users by lifecycle stage based on activity within the date range. The reference date is `date_to`.\n\nDefault stage thresholds can be overridden per-request with the lifecycle threshold query params (`new_window_days`, `churn_window_days`, `power_user_min_active_days`, `power_user_window_days`, `resurrected_gap_days`, `at_risk_min_days_inactive`, `at_risk_prior_active_days_threshold`); each is an optional integer 1 to 90. When omitted, the project's saved Settings → Lifecycle values apply, then the platform defaults.",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -7069,9 +7008,7 @@
       "get": {
         "operationId": "getAnalyticsFrequency",
         "summary": "Get visit-frequency distribution",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -7209,9 +7146,7 @@
       "get": {
         "operationId": "getAnalyticsRetention",
         "summary": "Get user retention cohorts",
-        "tags": [
-          "Query"
-        ],
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -7228,10 +7163,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "address",
-                "anonymous_id"
-              ],
+              "enum": ["address", "anonymous_id"],
               "default": "address"
             },
             "description": "User identifier to cohort by. `address` (default) groups by wallet; `anonymous_id` groups by anonymous session ID."
@@ -7423,10 +7355,8 @@
       "get": {
         "operationId": "getAnalyticsFunnel",
         "summary": "Get multi-step conversion funnel",
-        "description": "Multi-step conversion funnel. For an ordered list of step specs, returns one row per step with the unique-user count, conversion ratios against step 1 and the previous step, drop-off ratio, and median time-to-convert (from-previous and from-start, in seconds).\n\n**Closed vs open:** `funnel_type=closed` (default) requires the user to fire the steps in order within `window_seconds`. `funnel_type=open` counts whoever fired step k regardless of order, and adds a `dropped_off_users` column for each step.\n\n**Breakdown:** when `group_by` is set to a column from the breakdown allowlist (`device`, `browser`, `os`, `location`, `referrer`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`), the response gains a `breakdown` column and is grouped per (step, top-N category + 'Others', up to `limit` which defaults to 5). First-touch attribution is used by default; pass `attribution=last_touch` to bucket by each user's latest value.\n\n**Steps:** the `steps` query param is a JSON-encoded array of 2 to 10 step specs of shape `{type, event, name, filters?: [{operand, operator, value}]}`. Use `name` (e.g. `\"page::0\"`) as a unique step id so the same event re-used at different steps can be disambiguated in the response. `operator` accepts `equals | notEquals | in | notIn | gt | lt | gte | lte | greater | greaterOrEqual | less | lessOrEqual | startsWith | endsWith | includes | notEmpty | isEmpty` (the short numeric aliases `gt`/`gte`/`lt`/`lte` and their canonical long forms are equivalent; `notEmpty`/`isEmpty` are value-less existence checks, rejected on the numeric event columns `volume`/`revenue`/`points`). `operand` may target a standard event column or a JSON property on `properties`.",
-        "tags": [
-          "Query"
-        ],
+        "description": "Multi-step conversion funnel. For an ordered list of step specs, returns one row per step with the unique-user count, conversion ratios against step 1 and the previous step, drop-off ratio, and median time-to-convert (from-previous and from-start, in seconds).\n\n**Closed vs open:** `funnel_type=closed` (default) requires the user to fire the steps in order within `window_seconds`. `funnel_type=open` counts whoever fired step k regardless of order, and adds a `dropped_off_users` column for each step.\n\n**Breakdown:** when `group_by` is set to a column from the breakdown allowlist (`device`, `browser`, `os`, `location`, `referrer`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`), the response gains a `breakdown` column and is grouped per (step, top-N category + 'Others', up to `limit` which defaults to 5). First-touch attribution is used by default; pass `attribution=last_touch` to bucket by each user's latest value.\n\n**Steps:** the `steps` query param is a JSON-encoded array of 2 to 10 step specs of shape `{type, event, name, filters?: [{operand, operator, value}]}`. Use `name` (e.g. `\"page::0\"`) as a unique step id so the same event re-used at different steps can be disambiguated in the response. `operator` accepts `eq | neq | in | nin | gt | lt | gte | lte | startsWith | endsWith | contains | notEmpty | isEmpty` (canonical tokens only — the retired long-form spellings are rejected; `notEmpty`/`isEmpty` are value-less existence checks, rejected on the numeric event columns `volume`/`revenue`/`points`). `operand` may target a standard event column or a JSON property on `properties`.",
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -7458,7 +7388,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "JSON-encoded array of 2 to 10 step specs. Each step is `{type, event, name, filters?: [{operand, operator, value}]}`. `type` is the event type (e.g. `event` for page views, `track` for custom events, `transaction`, `signature`, `decoded_log`). `event` is the event name. `name` is the unique step id (use `\"<event>::<index>\"` to disambiguate repeated events).\n\n**Filter operators:** `equals`, `notEquals`, `in`, `notIn`, `gt`, `lt`, `gte`, `lte`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `startsWith`, `endsWith`, `includes`, `notEmpty`, `isEmpty` (the short numeric aliases and their canonical long forms are equivalent; `notEmpty`/`isEmpty` are value-less existence checks, rejected on numeric event columns `volume`/`revenue`/`points`). For `in`/`notIn`, pass the values as a `|`-separated string in `value` (e.g. `\"ethereum|polygon|base\"`).\n\n**Standard columns** (rendered via direct column access): `origin`, `device`, `browser`, `os`, `location`, `referrer`, `direct`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`, `version`, `locale`, `timezone`, `page_path`. Anything else is treated as a JSON property and read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
+            "description": "JSON-encoded array of 2 to 10 step specs. Each step is `{type, event, name, filters?: [{operand, operator, value}]}`. `type` is the event type (e.g. `event` for page views, `track` for custom events, `transaction`, `signature`, `decoded_log`). `event` is the event name. `name` is the unique step id (use `\"<event>::<index>\"` to disambiguate repeated events).\n\n**Filter operators:** `eq`, `neq`, `in`, `nin`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty` (canonical tokens only — the retired long-form spellings `equals`/`greater`/`includes`/… are rejected; `notEmpty`/`isEmpty` are value-less existence checks, rejected on numeric event columns `volume`/`revenue`/`points`). For `in`/`nin`, pass the values as a `|`-separated string in `value` (e.g. `\"ethereum|polygon|base\"`).\n\n**Standard columns** (rendered via direct column access): `origin`, `device`, `browser`, `os`, `location`, `referrer`, `direct`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`, `version`, `locale`, `timezone`, `page_path`. Anything else is treated as a JSON property and read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
             "examples": {
               "simple": {
                 "summary": "Simple 3-step funnel: page → connect → swap",
@@ -7466,7 +7396,7 @@
               },
               "standardColumnFilter": {
                 "summary": "Step filter on a standard column (mobile-only first step)",
-                "value": "[{\"type\":\"event\",\"event\":\"page\",\"name\":\"page::0\",\"filters\":[{\"operand\":\"device\",\"operator\":\"equals\",\"value\":\"mobile\"}]},{\"type\":\"track\",\"event\":\"signup\",\"name\":\"signup::1\",\"filters\":[]}]"
+                "value": "[{\"type\":\"event\",\"event\":\"page\",\"name\":\"page::0\",\"filters\":[{\"operand\":\"device\",\"operator\":\"eq\",\"value\":\"mobile\"}]},{\"type\":\"track\",\"event\":\"signup\",\"name\":\"signup::1\",\"filters\":[]}]"
               },
               "utmSourceIn": {
                 "summary": "Step filter using `in` on a standard column (UTM-attributed sessions)",
@@ -7478,7 +7408,7 @@
               },
               "jsonPropertyFilter": {
                 "summary": "Step property filter (JSON property `provider_name=MetaMask`)",
-                "value": "[{\"type\":\"track\",\"event\":\"connect\",\"name\":\"connect::0\",\"filters\":[{\"operand\":\"provider_name\",\"operator\":\"equals\",\"value\":\"MetaMask\"}]},{\"type\":\"track\",\"event\":\"swap\",\"name\":\"swap::1\",\"filters\":[]}]"
+                "value": "[{\"type\":\"track\",\"event\":\"connect\",\"name\":\"connect::0\",\"filters\":[{\"operand\":\"provider_name\",\"operator\":\"eq\",\"value\":\"MetaMask\"}]},{\"type\":\"track\",\"event\":\"swap\",\"name\":\"swap::1\",\"filters\":[]}]"
               },
               "jsonNumericFilter": {
                 "summary": "Step property filter using a numeric comparator (price > 100 → JSONExtractFloat)",
@@ -7486,11 +7416,11 @@
               },
               "combinedFilters": {
                 "summary": "Step with multiple filters (standard column + JSON property)",
-                "value": "[{\"type\":\"event\",\"event\":\"page\",\"name\":\"page::0\",\"filters\":[{\"operand\":\"device\",\"operator\":\"equals\",\"value\":\"desktop\"},{\"operand\":\"page_path\",\"operator\":\"startsWith\",\"value\":\"/earn\"}]},{\"type\":\"track\",\"event\":\"deposit\",\"name\":\"deposit::1\",\"filters\":[{\"operand\":\"chain_id\",\"operator\":\"equals\",\"value\":\"1\"},{\"operand\":\"asset\",\"operator\":\"in\",\"value\":\"USDC|USDT|DAI\"}]}]"
+                "value": "[{\"type\":\"event\",\"event\":\"page\",\"name\":\"page::0\",\"filters\":[{\"operand\":\"device\",\"operator\":\"eq\",\"value\":\"desktop\"},{\"operand\":\"page_path\",\"operator\":\"startsWith\",\"value\":\"/earn\"}]},{\"type\":\"track\",\"event\":\"deposit\",\"name\":\"deposit::1\",\"filters\":[{\"operand\":\"chain_id\",\"operator\":\"eq\",\"value\":\"1\"},{\"operand\":\"asset\",\"operator\":\"in\",\"value\":\"USDC|USDT|DAI\"}]}]"
               },
               "transactionStatus": {
                 "summary": "Onchain step (`transaction` type, success-only via JSON property)",
-                "value": "[{\"type\":\"event\",\"event\":\"page\",\"name\":\"page::0\",\"filters\":[]},{\"type\":\"transaction\",\"event\":\"swap\",\"name\":\"swap::1\",\"filters\":[{\"operand\":\"status\",\"operator\":\"equals\",\"value\":\"success\"}]}]"
+                "value": "[{\"type\":\"event\",\"event\":\"page\",\"name\":\"page::0\",\"filters\":[]},{\"type\":\"transaction\",\"event\":\"swap\",\"name\":\"swap::1\",\"filters\":[{\"operand\":\"status\",\"operator\":\"eq\",\"value\":\"success\"}]}]"
               }
             }
           },
@@ -7510,10 +7440,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "closed",
-                "open"
-              ],
+              "enum": ["closed", "open"],
               "default": "closed"
             },
             "description": "`closed` (default): ordered, in-window. `open`: unordered per-step; emits an extra `dropped_off_users` column."
@@ -7571,15 +7498,42 @@
                 },
                 "example": {
                   "meta": [
-                    { "name": "step", "type": "UInt64" },
-                    { "name": "event", "type": "String" },
-                    { "name": "users", "type": "UInt64" },
-                    { "name": "total", "type": "UInt64" },
-                    { "name": "conversion_from_start", "type": "Nullable(Float64)" },
-                    { "name": "conversion_from_previous", "type": "Nullable(Float64)" },
-                    { "name": "dropoff_from_previous", "type": "Nullable(Float64)" },
-                    { "name": "median_seconds_from_previous", "type": "Nullable(Float64)" },
-                    { "name": "median_seconds_from_start", "type": "Nullable(Float64)" }
+                    {
+                      "name": "step",
+                      "type": "UInt64"
+                    },
+                    {
+                      "name": "event",
+                      "type": "String"
+                    },
+                    {
+                      "name": "users",
+                      "type": "UInt64"
+                    },
+                    {
+                      "name": "total",
+                      "type": "UInt64"
+                    },
+                    {
+                      "name": "conversion_from_start",
+                      "type": "Nullable(Float64)"
+                    },
+                    {
+                      "name": "conversion_from_previous",
+                      "type": "Nullable(Float64)"
+                    },
+                    {
+                      "name": "dropoff_from_previous",
+                      "type": "Nullable(Float64)"
+                    },
+                    {
+                      "name": "median_seconds_from_previous",
+                      "type": "Nullable(Float64)"
+                    },
+                    {
+                      "name": "median_seconds_from_start",
+                      "type": "Nullable(Float64)"
+                    }
                   ],
                   "data": [
                     {
@@ -7659,10 +7613,8 @@
       "get": {
         "operationId": "getAnalyticsFlow",
         "summary": "Get session-scoped user-flow transitions (Sankey)",
-        "description": "Session-scoped user-flow transitions for Sankey-style charts. Given a required `start_step`, optional `end_step`, date window, conversion window, and max-step cap, returns one row per `(step, source, target)` transition with counts and per-step percentages.\n\n**How it works:** for each session that fires the start step inside `[date_from, date_to]`, the endpoint rebuilds the ordered sequence of subsequent events within the conversion window (`window_seconds`), normalises each event into a flow-node label (page path for `page`, event name for `track`/`decoded_log`, prefixed for `signature`/`transaction`), truncates at the first end-step match (when `end_step` is set), and slices to `max_steps + 1` nodes. Adjacent nodes are then exploded into `(step, source, target)` edges with counts and percentages.\n\n**Converter-only mode:** when `end_step` is set, only sessions that actually reached the end event within the window are kept, and the matched event is suffixed with `__END_MATCH__`. This mirrors PostHog's `pathsFilter.endPoint` behaviour; every visible link is part of a converting path.\n\n**Step shape:** `start_step` and `end_step` are JSON objects of shape `{type, event, resolved_event, filters?: [...], status_type?, status_value?}`. `resolved_event` is the value used to match against the events table (event name, page path, or the sentinel `__ALL_PAGE_VIEWS__` for any page view). `filters` and `global_filters` accept `{operand, operator, value, values?}` (use `values` for `in`/`notIn`).",
-        "tags": [
-          "Query"
-        ],
+        "description": "Session-scoped user-flow transitions for Sankey-style charts. Given a required `start_step`, optional `end_step`, date window, conversion window, and max-step cap, returns one row per `(step, source, target)` transition with counts and per-step percentages.\n\n**How it works:** for each session that fires the start step inside `[date_from, date_to]`, the endpoint rebuilds the ordered sequence of subsequent events within the conversion window (`window_seconds`), normalises each event into a flow-node label (page path for `page`, event name for `track`/`decoded_log`, prefixed for `signature`/`transaction`), truncates at the first end-step match (when `end_step` is set), and slices to `max_steps + 1` nodes. Adjacent nodes are then exploded into `(step, source, target)` edges with counts and percentages.\n\n**Converter-only mode:** when `end_step` is set, only sessions that actually reached the end event within the window are kept, and the matched event is suffixed with `__END_MATCH__`. This mirrors PostHog's `pathsFilter.endPoint` behaviour; every visible link is part of a converting path.\n\n**Step shape:** `start_step` and `end_step` are JSON objects of shape `{type, event, resolved_event, filters?: [...], status_type?, status_value?}`. `resolved_event` is the value used to match against the events table (event name, page path, or the sentinel `__ALL_PAGE_VIEWS__` for any page view). `filters` and `global_filters` accept `{operand, operator, value, values?}` (use `values` for `in`/`nin`).",
+        "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
           {
@@ -7694,7 +7646,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "JSON-encoded start-step spec of shape `{type, event, resolved_event, filters?: [...], status_type?, status_value?}`. Use `\"resolved_event\":\"__ALL_PAGE_VIEWS__\"` to match any page view; pass a page path for a specific landing page; or pass an event name for `track`/`decoded_log` start events. `filters` use `{operand, operator, value, values?}` (use `values` for `in`/`notIn`).\n\n**Filter operators:** `equals`, `notEquals`, `in`, `notIn`, `gt`, `lt`, `gte`, `lte`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `startsWith`, `endsWith`, `includes`, `notEmpty`, `isEmpty` (the short numeric aliases and their canonical long forms are equivalent; `notEmpty`/`isEmpty` are value-less existence checks, rejected on numeric event columns `volume`/`revenue`/`points`). Standard columns (`device`, `browser`, `os`, `location`, `referrer`, `utm_*`, `page_path`, etc.) are read directly; everything else is read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
+            "description": "JSON-encoded start-step spec of shape `{type, event, resolved_event, filters?: [...], status_type?, status_value?}`. Use `\"resolved_event\":\"__ALL_PAGE_VIEWS__\"` to match any page view; pass a page path for a specific landing page; or pass an event name for `track`/`decoded_log` start events. `filters` use `{operand, operator, value, values?}` (use `values` for `in`/`nin`).\n\n**Filter operators:** `eq`, `neq`, `in`, `nin`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty` (canonical tokens only — the retired long-form spellings `equals`/`greater`/`includes`/… are rejected; `notEmpty`/`isEmpty` are value-less existence checks, rejected on numeric event columns `volume`/`revenue`/`points`). Standard columns (`device`, `browser`, `os`, `location`, `referrer`, `utm_*`, `page_path`, etc.) are read directly; everything else is read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
             "examples": {
               "anyPageView": {
                 "summary": "Match any page view as the start step",
@@ -7710,7 +7662,7 @@
               },
               "withStandardFilter": {
                 "summary": "Step filter on a standard column (mobile sessions only)",
-                "value": "{\"type\":\"event\",\"event\":\"page\",\"resolved_event\":\"__ALL_PAGE_VIEWS__\",\"filters\":[{\"operand\":\"device\",\"operator\":\"equals\",\"value\":\"mobile\"}]}"
+                "value": "{\"type\":\"event\",\"event\":\"page\",\"resolved_event\":\"__ALL_PAGE_VIEWS__\",\"filters\":[{\"operand\":\"device\",\"operator\":\"eq\",\"value\":\"mobile\"}]}"
               },
               "withInValuesFilter": {
                 "summary": "Step filter using `in` with the `values` array",
@@ -7718,7 +7670,7 @@
               },
               "withJsonPropertyFilter": {
                 "summary": "Step property filter (JSON property `provider_name=MetaMask`)",
-                "value": "{\"type\":\"track\",\"event\":\"connect\",\"resolved_event\":\"connect\",\"filters\":[{\"operand\":\"provider_name\",\"operator\":\"equals\",\"value\":\"MetaMask\"}]}"
+                "value": "{\"type\":\"track\",\"event\":\"connect\",\"resolved_event\":\"connect\",\"filters\":[{\"operand\":\"provider_name\",\"operator\":\"eq\",\"value\":\"MetaMask\"}]}"
               },
               "transactionWithStatus": {
                 "summary": "Onchain transaction matched via `status_type` + `status_value`",
@@ -7740,7 +7692,7 @@
               },
               "endWithFilter": {
                 "summary": "Conversion goal with a JSON property filter (premium plan only)",
-                "value": "{\"type\":\"track\",\"event\":\"upgrade\",\"resolved_event\":\"upgrade\",\"filters\":[{\"operand\":\"plan\",\"operator\":\"equals\",\"value\":\"premium\"}]}"
+                "value": "{\"type\":\"track\",\"event\":\"upgrade\",\"resolved_event\":\"upgrade\",\"filters\":[{\"operand\":\"plan\",\"operator\":\"eq\",\"value\":\"premium\"}]}"
               },
               "transactionEnd": {
                 "summary": "Successful onchain transaction as the end step",
@@ -7758,7 +7710,7 @@
             "examples": {
               "deviceFilter": {
                 "summary": "Restrict to desktop sessions",
-                "value": "[{\"operand\":\"device\",\"operator\":\"equals\",\"value\":\"desktop\"}]"
+                "value": "[{\"operand\":\"device\",\"operator\":\"eq\",\"value\":\"desktop\"}]"
               },
               "utmCohort": {
                 "summary": "Restrict to paid UTM cohorts using `in`",
@@ -7766,11 +7718,11 @@
               },
               "jsonProperty": {
                 "summary": "Filter by a JSON property (MetaMask wallet only)",
-                "value": "[{\"operand\":\"provider_name\",\"operator\":\"equals\",\"value\":\"MetaMask\"}]"
+                "value": "[{\"operand\":\"provider_name\",\"operator\":\"eq\",\"value\":\"MetaMask\"}]"
               },
               "combined": {
                 "summary": "Combine standard column + JSON property filters",
-                "value": "[{\"operand\":\"device\",\"operator\":\"equals\",\"value\":\"desktop\"},{\"operand\":\"chain_id\",\"operator\":\"equals\",\"value\":\"1\"}]"
+                "value": "[{\"operand\":\"device\",\"operator\":\"eq\",\"value\":\"desktop\"},{\"operand\":\"chain_id\",\"operator\":\"eq\",\"value\":\"1\"}]"
               }
             }
           },
@@ -7808,11 +7760,26 @@
                 },
                 "example": {
                   "meta": [
-                    { "name": "step", "type": "UInt32" },
-                    { "name": "source", "type": "String" },
-                    { "name": "target", "type": "String" },
-                    { "name": "transitions", "type": "UInt64" },
-                    { "name": "percentage", "type": "Float64" }
+                    {
+                      "name": "step",
+                      "type": "UInt32"
+                    },
+                    {
+                      "name": "source",
+                      "type": "String"
+                    },
+                    {
+                      "name": "target",
+                      "type": "String"
+                    },
+                    {
+                      "name": "transitions",
+                      "type": "UInt64"
+                    },
+                    {
+                      "name": "percentage",
+                      "type": "Float64"
+                    }
                   ],
                   "data": [
                     {
@@ -7888,9 +7855,7 @@
         "operationId": "ingestEvents",
         "summary": "Ingest events",
         "description": "Send analytics events to Formo. This endpoint runs on events.formo.so (not api.formo.so). Authenticate with your project's SDK write key.",
-        "tags": [
-          "Events"
-        ],
+        "tags": ["Events"],
         "servers": [
           {
             "url": "https://events.formo.so"

--- a/api/profiles/search.mdx
+++ b/api/profiles/search.mdx
@@ -150,7 +150,7 @@ Each condition in the `conditions` array has:
 | `isEmpty` | Field is not set (empty). String user attributes only — value is ignored | `{"field": "users.utm_source", "op": "isEmpty"}` |
 
 <Note>
-**Deprecated aliases.** The long-form spellings `equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, and `includes` are deprecated but still accepted on this endpoint — they are folded to the canonical operators above at the input boundary, so existing integrations keep working. Use the canonical operators for new integrations; the aliases may be retired in a future release. `notEmpty` / `isEmpty` are value-less existence checks (any `value` is ignored) and are supported on string user/profile attributes only — not on numeric metrics (`net_worth_usd`, `volume`, `revenue`, `points`), the `lifecycle` enum, or chain/app/token/label fields.
+**Legacy spellings are retired.** The long-form spellings `equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, and `includes` (and symbol forms like `=` / `!=` / `like`) are no longer accepted on this endpoint — a request carrying one is rejected with a `400` whose message names the offending token. Send only the canonical operators above. `notEmpty` / `isEmpty` are value-less existence checks (any `value` is ignored) and are supported on string user/profile attributes only — not on numeric metrics (`net_worth_usd`, `volume`, `revenue`, `points`), the `lifecycle` enum, or chain/app/token/label fields.
 </Note>
 
 ---

--- a/api/query/flow.mdx
+++ b/api/query/flow.mdx
@@ -15,7 +15,7 @@ Both `start_step` and `end_step` are JSON-encoded objects of shape `{type, event
 - **`type`** - event type (`event`, `track`, `transaction`, `signature`, `decoded_log`).
 - **`event`** - the event name.
 - **`resolved_event`** - the value matched against the events table. Use the sentinel `"__ALL_PAGE_VIEWS__"` to match any page view, or the page path / event name otherwise.
-- **`filters`** - optional `[{operand, operator, value, values?}]`. Use `values` for the `in` / `notIn` operators.
+- **`filters`** - optional `[{operand, operator, value, values?}]`. Use `values` for the `in` / `nin` operators. Operators use the canonical tokens only (`eq`, `neq`, `in`, `nin`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty`) — retired long-form spellings like `equals` / `notIn` / `includes` are rejected with a `400` naming the token.
 
 Pass `global_filters` as a JSON-encoded array to apply additional `{operand, operator, value, values?}` constraints to both the start-session scan and the relevant-events scan.
 

--- a/api/query/funnel.mdx
+++ b/api/query/funnel.mdx
@@ -23,19 +23,20 @@ The `steps` query parameter is a JSON-encoded array of 2 to 10 step specs. Each 
 - **`name`** - a unique step id. Use `<event>::<index>` (e.g. `"connect::1"`) so the same event re-used at multiple steps can be told apart in the response.
 - **`filters`** - optional `[{operand, operator, value}]`.
   - **Operators:**
-    - `equals`
-    - `notEquals`
+    - `eq`
+    - `neq`
     - `in`
-    - `notIn`
+    - `nin`
     - `gt`
     - `lt`
     - `gte`
     - `lte`
     - `startsWith`
     - `endsWith`
-    - `includes`
+    - `contains`
     - `notEmpty` / `isEmpty` - value-less existence checks (the `value` is ignored; rejected on the numeric event columns `volume`/`revenue`/`points`)
-  - The numeric long forms `greater`, `greaterOrEqual`, `less`, `lessOrEqual` are accepted as equivalents of `gt` / `gte` / `lt` / `lte`.
+  - Canonical tokens only: the retired long-form spellings (`equals`, `notEquals`, `notIn`, `includes`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`) are rejected with a `400` naming the token.
+  - For `in` / `nin`, pass the values as a `|`-separated string in `value` (e.g. `"ethereum|polygon|base"`).
   - **`operand`** may target a standard event column or a JSON property on `properties`.
 
 ## Example
@@ -49,6 +50,6 @@ curl -G "https://api.formo.so/v0/funnel" \
   --data-urlencode 'steps=[
     {"type":"event","event":"page","name":"page::0","filters":[]},
     {"type":"track","event":"connect","name":"connect::1","filters":[]},
-    {"type":"track","event":"swap","name":"swap::2","filters":[{"operand":"chain","operator":"equals","value":"ethereum"}]}
+    {"type":"track","event":"swap","name":"swap::2","filters":[{"operand":"chain","operator":"eq","value":"ethereum"}]}
   ]'
 ```

--- a/cli/profiles.mdx
+++ b/cli/profiles.mdx
@@ -127,7 +127,7 @@ The response is a paginated envelope: `{ data, total, page, size, has_more }`.
 
 `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `notEmpty`, `isEmpty`
 
-The long-form spellings (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`) are deprecated aliases — still accepted by the API, but new usage should stick to the canonical operators above.
+The long-form spellings (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`) are retired — the API rejects them with a `400` naming the token. Use only the canonical operators above.
 
 ---
 


### PR DESCRIPTION
## Why

P-2373 Phase A+B (formono `71c36bf89`, shipped to prod today) fully retired the filter alias-folding / dual-accept layer. This **supersedes** the state these docs were written against (#114), where the long-form spellings were "deprecated but still accepted / folded at the input boundary". As of today:

- Only the 13 canonical terse tokens are accepted anywhere: `eq`, `neq`, `in`, `nin`, `gt`, `gte`, `lt`, `lte`, `contains`, `startsWith`, `endsWith`, `notEmpty`, `isEmpty`.
- `/v0/profiles` and the funnel/flow/chart/alert filter surfaces reject `equals`/`notEquals`/`greater`/`greaterOrEqual`/`less`/`lessOrEqual`/`notIn`/`includes` (and `like`/symbol forms) with a `400` naming the token.
- All five op-enum sites in the OpenAPI spec are canonical-only (`FilterCondition` no longer lists the aliases).

## Changes

- **api/openapi.json** — synced with the shipped backend spec (verified semantically identical to `apps/backend/src/openapi.json` at prod HEAD): FilterCondition enum drops the 8 alias entries; alias-acceptance wording removed from all five op descriptions; funnel/flow/segments examples use canonical tokens.
- **api/profiles/search.mdx** — "deprecated but still accepted … folded" → retired + `400` naming the token.
- **api/boards/create-chart.mdx** — both Tips: numeric long forms "remain accepted" → rejected with a `400`.
- **api/query/funnel.mdx** — step-filter operator list was still the long-form dialect (`equals`/`notEquals`/`notIn`/`includes`) with "long forms accepted as equivalents"; now the canonical dialect (`eq`/`neq`/`nin`/`contains`), curl example uses `"operator":"eq"`, and the pipe-delimited `in`/`nin` value note matches the shipped spec.
- **api/query/flow.mdx** — `notIn` → `nin`; canonical-only note added.
- **cli/profiles.mdx** — "still accepted by the API" → rejected with a `400`.

## Verification

- `python3` semantic JSON compare of `api/openapi.json` vs formono `apps/backend/src/openapi.json`: **identical**.
- `npx mintlify validate`: build validation passed. `mintlify broken-links`: none.
- Repo-wide grep: no remaining alias-acceptance claims or long-form operator tokens presented as valid input (remaining "deprecated alias" hits are unrelated CLI flags `--name`/`--status paused`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787486617&installation_model_id=21031&pr_number=115&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F115&signature=c32dbc5c3c413b8f68637b8a0d87bcd4a7e4dea562c6cb077d601ebfdd48c543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->