### PR TITLE
Docs: Ad Attribution feature page + click-ID coverage

### DIFF
--- a/data/attribution.mdx
+++ b/data/attribution.mdx
@@ -100,6 +100,10 @@ Formo solves two core functions: attribution and identity.
 
 Spend less time building analytics and leave the complex data engineering to us.
 
+### Ad click IDs
+
+Paid acquisition is attributed with ad-platform click IDs (`gclid`, `fbclid`, `twclid`, and friends): the identifier each ad network appends to your landing page URL. Formo captures them automatically, classifies the acquiring network (Google Ads, Meta Ads, X Ads, TikTok Ads, LinkedIn Ads, Reddit Ads, Microsoft Ads), and uses them for channel classification even when the referrer is missing (common with in-app browsers). See [Ads](/features/product-analytics/ads) for the supported platforms and every dashboard surface they power.
+
 ### Attribution models
 
 Formo helps you understand the impact of touchpoints in each user journey using single-touch attribution, crediting either the first or the last touchpoint within the lookback window.

--- a/data/what-we-collect.mdx
+++ b/data/what-we-collect.mdx
@@ -175,6 +175,20 @@ We track these UTM codes:
 - `utm_content` (e.g.: summer_sale)
 - `utm_term` (e.g.: summer_sale)
 
+### Ad click IDs
+
+> We collect and store ad-platform click IDs.
+
+Ad platforms append a click identifier to your landing page URL when a user clicks an ad. We capture these parameters to attribute traffic and users to the acquiring ad network (see [Ads](/features/product-analytics/ads)):
+
+- `gclid` and `gad_source` (Google Ads)
+- `fbclid` (Meta Ads)
+- `msclkid` (Microsoft Ads)
+- `ttclid` (TikTok Ads)
+- `twclid` (X Ads)
+- `li_fat_id` (LinkedIn Ads)
+- `rdt_cid` (Reddit Ads)
+
 ### Referral
 
 > We collect and store referral parameters.

--- a/docs.json
+++ b/docs.json
@@ -26,6 +26,7 @@
                 "pages": [
                   "features/product-analytics/overview",
                   "features/product-analytics/key-metrics",
+                  "features/product-analytics/ads",
                   "features/product-analytics/activity",
                   "features/product-analytics/live-view",
                   "features/product-analytics/custom-events",

--- a/features/product-analytics/ads.mdx
+++ b/features/product-analytics/ads.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Ads'
-description: 'Measure which ad networks acquire your visitors, wallets, and conversions. Formo attributes traffic from Google, Meta, X, TikTok, LinkedIn, Reddit, and Microsoft ads automatically using click IDs.'
+title: 'Ad Attribution'
+description: 'Measure which ad networks acquire your visitors, wallets, and conversions. Formo attributes traffic from Google, Meta, X, TikTok, LinkedIn, Reddit, and Microsoft ads automatically using click IDs, surfaced in the Ads tab and filters.'
 ---
 
 Formo attributes traffic and users to the ad network that acquired them: no pixel, no postback setup. When someone clicks your ad, the platform appends a click ID to your landing page URL; the Formo SDK captures it automatically and every dashboard surface can then slice by ad network.

--- a/features/product-analytics/ads.mdx
+++ b/features/product-analytics/ads.mdx
@@ -1,0 +1,42 @@
+---
+title: 'Ads'
+description: 'Measure which ad networks acquire your visitors, wallets, and conversions. Formo attributes traffic from Google, Meta, X, TikTok, LinkedIn, Reddit, and Microsoft ads automatically using click IDs.'
+---
+
+Formo attributes traffic and users to the ad network that acquired them: no pixel, no postback setup. When someone clicks your ad, the platform appends a click ID to your landing page URL; the Formo SDK captures it automatically and every dashboard surface can then slice by ad network.
+
+## Supported ad platforms
+
+| Platform | Click ID parameter |
+| --- | --- |
+| Google Ads | `gclid`, `gad_source` |
+| Meta Ads | `fbclid` |
+| Microsoft Ads | `msclkid` |
+| TikTok Ads | `ttclid` |
+| X Ads | `twclid` |
+| LinkedIn Ads | `li_fat_id` |
+| Reddit Ads | `rdt_cid` |
+| Other Paid | any paid `utm_medium` (`cpc`, `cpm`, `ppc`, `paid*`, etc.) without a click ID |
+
+There is nothing to configure. Keep auto-tagging enabled on your ad platform (it is the default on all of them) and the click IDs arrive on your landing URLs. Adding UTM parameters as well gives you campaign-level detail on top of the network-level attribution; see the [UTM guide](https://formo.so/utm-generator).
+
+## How attribution works
+
+- **Sessions** attribute to the session's first paid touch. An organic landing followed by an ad click in the same session still counts for the ad network.
+- **Users** carry first-touch and last-touch ad attribution across their whole history, so you can analyze acquisition (first touch) or conversion influence (last touch).
+- Ads is one level more granular than [Channels](/data/attribution): the Paid Search and Paid Social channels group networks by ad format, while Ads shows the individual network.
+
+## Where Ads appears
+
+- **Overview → Acquisition card → Ads tab**: paid sessions and visitors by network. Click a row to jump to the Users page filtered to that network.
+- **Overview chart breakdown**: break Visitors, Sessions, Page views, Wallets, or Transactions down by Ads (Acquisition group in the breakdown picker).
+- **Users page**: filter by **Ads** (network) or **Ad Click ID** (raw token) in first-touch, last-touch, or any-touch mode. The users table has an **Ad** column, and each profile shows **Ad** and **Ad Click ID** rows with first and last touch.
+- **Activity page**: filter the event feed and chart by Ads or Ad Click ID.
+- **Funnels**: break conversion funnels down by Ads to compare conversion rates per network, or restrict a funnel to a saved segment with an Ads filter.
+- **Retention**: segment retention cohorts by Ads.
+- **API**: `/v0/top_sources?metric_column=paid_source` for the breakdown, and `/v0/profiles` returns and filters the user-level attribution columns. See the [API reference](/api).
+
+## Notes
+
+- Click IDs also feed [channel classification](/data/attribution): a click from a known ad platform classifies as Paid Search or Paid Social even when the referrer is missing (common with in-app browsers).
+- Ad click IDs are opaque tokens. Formo stores them for filtering and future conversion-export use cases; they are not shown as charts.


### PR DESCRIPTION
Adds public docs for the Ads attribution feature shipping in getformo/formono#2088:

- **New page** `features/product-analytics/ads`: supported ad platforms (Google/Meta/Microsoft/TikTok/X/LinkedIn/Reddit + Other Paid) with their click-ID parameters, how session-entry and user first/last-touch attribution work, and every dashboard surface (Acquisition card Ads tab, overview chart breakdown, Users + Activity filters, funnel breakdown, retention segments, profile rows, public API). Registered in the Product Analytics nav after Key metrics.
- `data/attribution`: an "Ad click IDs" section linking to the feature page.
- `data/what-we-collect`: the 8 click-ID URL parameters, next to the existing UTM section.

Note: describes UI that ships with formono#2088; merge this after (or together with) that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787570144&installation_model_id=21031&pr_number=116&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F116&signature=87004cf06dc672ba352f5e29f5a3a221f375dfd1484447f3b26ad2c46fe530a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->