### PR TITLE
Add reverse proxy setup guide for ad blocker mitigation

### DIFF
--- a/install.mdx
+++ b/install.mdx
@@ -798,6 +798,20 @@ Go to your browser's Network tab and look for successful 'raw_events' request in
 
 Events that are tracked correctly will show up in the [Activity page](/features/product-analytics/activity) of your Formo workspace.
 
+If the request never appears, an ad blocker or privacy browser is likely blocking it. Set up a [reverse proxy](#proxy) to route events through your own domain.
+
+## Proxy
+
+Ad blockers and privacy browsers block requests to known analytics domains, including `events.formo.so`. Before going to production, set up a reverse proxy so events are sent through your own domain, then pass that URL as `apiHost` in your SDK options.
+
+This applies to every installation method above. If you use the HTML snippet, also serve the script from your own domain instead of `cdn.formo.so`.
+
+<CardGroup>
+  <Card title="Set up a reverse proxy" icon="shield-halved" iconType="regular" href="/sdks/web#proxy">
+    Next.js rewrites, Next.js middleware, Cloudflare, CloudFront, and self-hosting the script
+  </Card>
+</CardGroup>
+
 ## SDK
 
 <CardGroup>

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -968,7 +968,7 @@ Here are the domains used by Formo to load the SDK and send data:
 Some ad blockers block specific scripts and API calls based on the domain name and URL. 
 To address this issue you can download and serve the Formo HTML Snippet from `cdn.formo.so` to your own domain e.g. `yourdomain.com/formo.js`.
 
-> If you use the Web SDK, you can skip this because they are not loaded from the CDN.
+> This only applies to the HTML snippet. If you installed `@formo/analytics` via NPM, the SDK is bundled with your app and is not loaded from the CDN, so you can skip this step.
 
 ### Next.js rewrites
 
@@ -981,7 +981,7 @@ module.exports = {
     return [
       {
         source: "/formo.js",
-        destination: "https://cdn.formo.so/analytics@latest", // Only if using HTML install script, skip if using the Web SDK
+        destination: "https://cdn.formo.so/analytics@latest", // Only for the HTML snippet, skip if you installed via NPM
       },
       {
         source: "/api/ingest",


### PR DESCRIPTION
## Summary
Added comprehensive documentation for setting up a reverse proxy to bypass ad blockers and privacy browser restrictions on analytics event tracking. This includes a new "Proxy" section in the installation guide with links to implementation details.

## Key changes
- Added troubleshooting note in `install.mdx` directing users to set up a reverse proxy if event requests don't appear due to ad blockers
- Created new "Proxy" section in `install.mdx` explaining the problem and solution, with a card linking to detailed setup instructions
- Clarified in `sdks/web.mdx` that CDN serving concerns only apply to the HTML snippet installation method, not NPM-based SDK installations
- Updated code comments in Next.js rewrite examples to be more explicit about when the proxy setup applies (HTML snippet vs NPM install)

## Notable details
- The new proxy section is positioned strategically after the activity page verification step, so users encounter it when troubleshooting missing events
- Documentation now clearly distinguishes between HTML snippet and NPM SDK installation methods, since they have different proxy requirements
- Updated language to avoid em dashes per project conventions

https://claude.ai/code/session_01T19axsf2ZrT38vhK1JkUKp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787707468&installation_model_id=21031&pr_number=117&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F117&signature=1f369dc006493ef234be7d5e550fac464852d3cf90cc9842fb594560310049ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->