### PR TITLE
Fix RetentionUserFilter field names and resync the spec with the API

### DIFF
--- a/api/boards/create-chart.mdx
+++ b/api/boards/create-chart.mdx
@@ -338,9 +338,9 @@ Each `RetentionUserFilter`:
 
 | Field   | Type             | Description                                                              |
 | ------- | ---------------- | ------------------------------------------------------------------------ |
-| `field` | string           | User property (e.g. `device`, `browser`, `os`, `utm_source`, `location`) |
-| `op`    | string           | Comparison operator (same set as `StepFilterCondition.op`, minus the substring operators `startsWith` / `endsWith` / `contains`)               |
-| `value` | string \| number | Value to compare against                                                 |
+| `operand`  | string           | User property (e.g. `device`, `browser`, `os`, `utm_source`, `location`) |
+| `operator` | string           | Comparison operator (same set as `StepFilterCondition.op`, minus the substring operators `startsWith` / `endsWith` / `contains`)               |
+| `value`    | string \| number | Value to compare against                                                 |
 
 ```json
 {
@@ -351,8 +351,8 @@ Each `RetentionUserFilter`:
   "settings": {
     "retentionFilter": { "type": "event", "event": "transaction" },
     "retentionUserFilters": [
-      { "field": "device", "op": "eq", "value": "desktop" },
-      { "field": "utm_source", "op": "neq", "value": "direct" }
+      { "operand": "device", "operator": "eq", "value": "desktop" },
+      { "operand": "utm_source", "operator": "neq", "value": "direct" }
     ]
   }
 }
@@ -751,9 +751,9 @@ Each `RetentionUserFilter`:
 
 | Field   | Type             | Description                                                              |
 | ------- | ---------------- | ------------------------------------------------------------------------ |
-| `field` | string           | User property (e.g. `device`, `browser`, `os`, `utm_source`, `location`) |
-| `op`    | string           | Comparison operator (same set as `StepFilterCondition.op`, minus the substring operators `startsWith` / `endsWith` / `contains`)               |
-| `value` | string \| number | Value to compare against                                                 |
+| `operand`  | string           | User property (e.g. `device`, `browser`, `os`, `utm_source`, `location`) |
+| `operator` | string           | Comparison operator (same set as `StepFilterCondition.op`, minus the substring operators `startsWith` / `endsWith` / `contains`)               |
+| `value`    | string \| number | Value to compare against                                                 |
 
 ```json
 {
@@ -764,8 +764,8 @@ Each `RetentionUserFilter`:
   "settings": {
     "retentionFilter": { "type": "event", "event": "transaction" },
     "retentionUserFilters": [
-      { "field": "device", "op": "eq", "value": "desktop" },
-      { "field": "utm_source", "op": "neq", "value": "direct" }
+      { "operand": "device", "operator": "eq", "value": "desktop" },
+      { "operand": "utm_source", "operator": "neq", "value": "direct" }
     ]
   }
 }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -231,7 +231,7 @@
       },
       "StepFilterCondition": {
         "type": "object",
-        "description": "A filter condition for an event property on a funnel step. The `op` field specifies the comparison operator and `value` is the value to compare against. For `in` and `nin` operators the value is a pipe-delimited string (e.g. `\"metamask|rainbow|coinbase\"`).",
+        "description": "A filter condition for an event property on a funnel step. Used as a value of `FunnelStep.additionalProperties`, so the filtered column is the PROPERTY KEY and this object carries only the comparison (e.g. `\"rdns\": { \"op\": \"eq\", \"value\": \"io.metamask\" }`). This is distinct from the `/v0/funnel` and `/v0/flow` `filters` arrays, whose entries name the column explicitly as `{operand, operator, value}`. For `in` and `nin` operators the value is a pipe-delimited string (e.g. `\"metamask|rainbow|coinbase\"`).",
         "properties": {
           "op": {
             "type": "string",
@@ -250,7 +250,7 @@
               "notEmpty",
               "isEmpty"
             ],
-            "description": "Comparison operator. Only the canonical terse tokens are accepted (the retired long forms `greater`/`greaterOrEqual`/`less`/`lessOrEqual` are rejected). Use `in` / `nin` for multi-value matching (pipe-delimited value string). `notEmpty` (\"is not empty\") and `isEmpty` (\"is empty\") are value-less existence checks on the property; the `value` is ignored. Existence checks are rejected on the numeric event columns `volume`/`revenue`/`points` — a number has no emptiness semantics."
+            "description": "Comparison operator. Only the canonical terse tokens are accepted (the retired long forms `greater`/`greaterOrEqual`/`less`/`lessOrEqual` are rejected). Use `in` / `nin` for multi-value matching (pipe-delimited value string). `notEmpty` (\"is not empty\") and `isEmpty` (\"is empty\") are value-less existence checks on the property; the `value` is ignored. Existence checks are rejected on the numeric event columns `volume`/`revenue`/`points`; a number has no emptiness semantics."
           },
           "value": {
             "oneOf": [
@@ -349,13 +349,13 @@
       },
       "RetentionUserFilter": {
         "type": "object",
-        "description": "A user-level segment filter applied to the retention chart cohort.",
+        "description": "A user-level segment filter applied to the retention chart cohort. Note that this object uses `operand`/`operator`, unlike the `field`/`op` spelling used by `FilterCondition`, `AnalyticsFilterCondition`, and `RetentionLabelSignal`.",
         "properties": {
-          "field": {
+          "operand": {
             "type": "string",
             "description": "The user property to filter on (e.g. `device`, `browser`, `os`, `location`, `utm_source`, `utm_medium`, `utm_campaign`)."
           },
-          "op": {
+          "operator": {
             "type": "string",
             "enum": [
               "eq",
@@ -383,7 +383,7 @@
             "description": "The value to compare against."
           }
         },
-        "required": ["field", "op", "value"]
+        "required": ["operand", "operator", "value"]
       },
       "RetentionLabelSignal": {
         "type": "object",
@@ -1028,6 +1028,26 @@
             "nullable": true,
             "description": "Last UTM term"
           },
+          "first_paid_source": {
+            "type": "string",
+            "nullable": true,
+            "description": "First-touch acquiring ad network (google, meta, microsoft, tiktok, twitter, linkedin, reddit, or paid_utm for pricing-medium UTMs with no click ID)"
+          },
+          "last_paid_source": {
+            "type": "string",
+            "nullable": true,
+            "description": "Last-touch acquiring ad network (same value set as first_paid_source)"
+          },
+          "first_click_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "First-touch raw ad-platform click ID (gclid, fbclid, msclkid, ttclid, twclid, li_fat_id, or rdt_cid)"
+          },
+          "last_click_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Last-touch raw ad-platform click ID"
+          },
           "last_type": {
             "type": "string",
             "nullable": true,
@@ -1592,10 +1612,12 @@
               "in",
               "nin",
               "contains",
+              "startsWith",
+              "endsWith",
               "notEmpty",
               "isEmpty"
             ],
-            "description": "Comparison operator. Only the canonical terse tokens (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `notEmpty`, `isEmpty`) are accepted; the retired long-form spellings (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`) are rejected with a 400 naming the token. `contains` (case-insensitive substring) is only supported on social fields (e.g. `users.twitter`, `users.email`). `notEmpty` (\"is not empty\" / \"is set\") is a string existence check for user string attributes (device/os/utm_*/referrer/…) and social fields; `isEmpty` (\"is empty\" / \"is not set\") is its complement, supported for user string attributes only (not social fields). Both ignore `value`. `users.lifecycle` supports only `eq` (a single stage) and `in` (a list of stages)."
+            "description": "Comparison operator. Only the canonical terse tokens (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `startsWith`, `endsWith`, `notEmpty`, `isEmpty`) are accepted; the retired long-form spellings (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`) are rejected with a 400 naming the token. **Substring operators:** `contains`, `startsWith` and `endsWith` are supported on routable string user attributes (`users.device`, `users.os`, `users.referrer`, `users.utm_*`, `users.click_id`, and the `first_*`/`last_*` attribution variants), where they match **case-sensitively**. Social fields (e.g. `users.twitter`, `users.email`) additionally support `contains`, which matches **case-insensitively** there; `startsWith`/`endsWith` are rejected on social fields. All three are rejected on numeric, chain/app/token/label and lifecycle fields. `notEmpty` (\"is not empty\" / \"is set\") is a string existence check for user string attributes (device/os/utm_*/referrer/…) and social fields; `isEmpty` (\"is empty\" / \"is not set\") is its complement, supported for user string attributes only (not social fields). Both ignore `value`. `users.lifecycle` supports only `eq` (a single stage) and `in` (a list of stages)."
           },
           "value": {
             "description": "Filter value (string, number, boolean, or array). Required for every operator except the existence checks `notEmpty` and `isEmpty`, which ignore it."
@@ -3371,8 +3393,8 @@
                       },
                       "retentionUserFilters": [
                         {
-                          "field": "device",
-                          "op": "eq",
+                          "operand": "device",
+                          "operator": "eq",
                           "value": "desktop"
                         }
                       ]
@@ -5692,10 +5714,11 @@
                 "device",
                 "browser",
                 "os",
-                "channel"
+                "channel",
+                "paid_source"
               ]
             },
-            "description": "Column to break down sources by. Use `channel` for the 12-channel acquisition classifier (see docs/channels.md)."
+            "description": "Column to break down sources by. Use `channel` for the 12-channel acquisition classifier (see docs/channels.md). Use `paid_source` for the session-entry acquiring ad network (paid sessions only; see docs/ads.md)."
           },
           {
             "$ref": "#/components/parameters/AnalyticsLimit"
@@ -7355,7 +7378,7 @@
       "get": {
         "operationId": "getAnalyticsFunnel",
         "summary": "Get multi-step conversion funnel",
-        "description": "Multi-step conversion funnel. For an ordered list of step specs, returns one row per step with the unique-user count, conversion ratios against step 1 and the previous step, drop-off ratio, and median time-to-convert (from-previous and from-start, in seconds).\n\n**Closed vs open:** `funnel_type=closed` (default) requires the user to fire the steps in order within `window_seconds`. `funnel_type=open` counts whoever fired step k regardless of order, and adds a `dropped_off_users` column for each step.\n\n**Breakdown:** when `group_by` is set to a column from the breakdown allowlist (`device`, `browser`, `os`, `location`, `referrer`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`), the response gains a `breakdown` column and is grouped per (step, top-N category + 'Others', up to `limit` which defaults to 5). First-touch attribution is used by default; pass `attribution=last_touch` to bucket by each user's latest value.\n\n**Steps:** the `steps` query param is a JSON-encoded array of 2 to 10 step specs of shape `{type, event, name, filters?: [{operand, operator, value}]}`. Use `name` (e.g. `\"page::0\"`) as a unique step id so the same event re-used at different steps can be disambiguated in the response. `operator` accepts `eq | neq | in | nin | gt | lt | gte | lte | startsWith | endsWith | contains | notEmpty | isEmpty` (canonical tokens only — the retired long-form spellings are rejected; `notEmpty`/`isEmpty` are value-less existence checks, rejected on the numeric event columns `volume`/`revenue`/`points`). `operand` may target a standard event column or a JSON property on `properties`.",
+        "description": "Multi-step conversion funnel. For an ordered list of step specs, returns one row per step with the unique-user count, conversion ratios against step 1 and the previous step, drop-off ratio, and median time-to-convert (from-previous and from-start, in seconds).\n\n**Closed vs open:** `funnel_type=closed` (default) requires the user to fire the steps in order within `window_seconds`. `funnel_type=open` counts whoever fired step k regardless of order, and adds a `dropped_off_users` column for each step.\n\n**Breakdown:** when `group_by` is set to a column from the breakdown allowlist (`device`, `browser`, `os`, `location`, `referrer`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`), the response gains a `breakdown` column and is grouped per (step, top-N category + 'Others', up to `limit` which defaults to 5). First-touch attribution is used by default; pass `attribution=last_touch` to bucket by each user's latest value.\n\n**Steps:** the `steps` query param is a JSON-encoded array of 2 to 10 step specs of shape `{type, event, name, filters?: [{operand, operator, value}]}`. Use `name` (e.g. `\"page::0\"`) as a unique step id so the same event re-used at different steps can be disambiguated in the response. `operator` accepts `eq | neq | in | nin | gt | lt | gte | lte | startsWith | endsWith | contains | notEmpty | isEmpty` (canonical tokens only; the retired long-form spellings are rejected, `notEmpty`/`isEmpty` are value-less existence checks, rejected on the numeric event columns `volume`/`revenue`/`points`). `operand` may target a standard event column or a JSON property on `properties`.",
         "tags": ["Query"],
         "x-required-scope": "query:read",
         "parameters": [
@@ -7388,7 +7411,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "JSON-encoded array of 2 to 10 step specs. Each step is `{type, event, name, filters?: [{operand, operator, value}]}`. `type` is the event type (e.g. `event` for page views, `track` for custom events, `transaction`, `signature`, `decoded_log`). `event` is the event name. `name` is the unique step id (use `\"<event>::<index>\"` to disambiguate repeated events).\n\n**Filter operators:** `eq`, `neq`, `in`, `nin`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty` (canonical tokens only — the retired long-form spellings `equals`/`greater`/`includes`/… are rejected; `notEmpty`/`isEmpty` are value-less existence checks, rejected on numeric event columns `volume`/`revenue`/`points`). For `in`/`nin`, pass the values as a `|`-separated string in `value` (e.g. `\"ethereum|polygon|base\"`).\n\n**Standard columns** (rendered via direct column access): `origin`, `device`, `browser`, `os`, `location`, `referrer`, `direct`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`, `version`, `locale`, `timezone`, `page_path`. Anything else is treated as a JSON property and read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
+            "description": "JSON-encoded array of 2 to 10 step specs. Each step is `{type, event, name, filters?: [{operand, operator, value}]}`. `type` is the event type (e.g. `event` for page views, `track` for custom events, `transaction`, `signature`, `decoded_log`). `event` is the event name. `name` is the unique step id (use `\"<event>::<index>\"` to disambiguate repeated events).\n\n**Filter operators:** `eq`, `neq`, `in`, `nin`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty` (canonical tokens only; the retired long-form spellings `equals`/`greater`/`includes`/… are rejected, `notEmpty`/`isEmpty` are value-less existence checks, rejected on numeric event columns `volume`/`revenue`/`points`). For `in`/`nin`, pass the values as a `|`-separated string in `value` (e.g. `\"ethereum|polygon|base\"`).\n\n**Standard columns** (rendered via direct column access): `origin`, `device`, `browser`, `os`, `location`, `referrer`, `direct`, `ref`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `builder_codes`, `version`, `locale`, `timezone`, `page_path`. Anything else is treated as a JSON property and read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
             "examples": {
               "simple": {
                 "summary": "Simple 3-step funnel: page → connect → swap",
@@ -7646,7 +7669,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "JSON-encoded start-step spec of shape `{type, event, resolved_event, filters?: [...], status_type?, status_value?}`. Use `\"resolved_event\":\"__ALL_PAGE_VIEWS__\"` to match any page view; pass a page path for a specific landing page; or pass an event name for `track`/`decoded_log` start events. `filters` use `{operand, operator, value, values?}` (use `values` for `in`/`nin`).\n\n**Filter operators:** `eq`, `neq`, `in`, `nin`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty` (canonical tokens only — the retired long-form spellings `equals`/`greater`/`includes`/… are rejected; `notEmpty`/`isEmpty` are value-less existence checks, rejected on numeric event columns `volume`/`revenue`/`points`). Standard columns (`device`, `browser`, `os`, `location`, `referrer`, `utm_*`, `page_path`, etc.) are read directly; everything else is read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
+            "description": "JSON-encoded start-step spec of shape `{type, event, resolved_event, filters?: [...], status_type?, status_value?}`. Use `\"resolved_event\":\"__ALL_PAGE_VIEWS__\"` to match any page view; pass a page path for a specific landing page; or pass an event name for `track`/`decoded_log` start events. `filters` use `{operand, operator, value, values?}` (use `values` for `in`/`nin`).\n\n**Filter operators:** `eq`, `neq`, `in`, `nin`, `gt`, `lt`, `gte`, `lte`, `startsWith`, `endsWith`, `contains`, `notEmpty`, `isEmpty` (canonical tokens only; the retired long-form spellings `equals`/`greater`/`includes`/… are rejected, `notEmpty`/`isEmpty` are value-less existence checks, rejected on numeric event columns `volume`/`revenue`/`points`). Standard columns (`device`, `browser`, `os`, `location`, `referrer`, `utm_*`, `page_path`, etc.) are read directly; everything else is read from `properties` via `JSONExtractString` (or `JSONExtractFloat` for numeric comparators).",
             "examples": {
               "anyPageView": {
                 "summary": "Match any page view as the start step",


### PR DESCRIPTION
## What was wrong

`api/openapi.json` documented `RetentionUserFilter` as `{field, op, value}`, all three required, in both the schema and a worked example under "Create a chart". The API has always required `{operand, operator, value}`, so anyone following the published example got a 400 for the two missing fields.

Confirmed against production, not inferred. A create-chart request carrying a bad operator reports the path:

```
body.settings.retentionUserFilters.0.operator
```

`api/boards/create-chart.mdx` repeats the same table and JSON sample twice, so both copies are corrected here too.

## The spec had also drifted from the backend

`api/openapi.json` is a copy of `apps/backend/src/openapi.json` in the formono repo. It had fallen behind in three places, all of them the docs lagging the API:

| Gap | Detail |
| --- | --- |
| `FilterCondition.op` | listed 11 operators, missing `startsWith` and `endsWith` |
| `Profile` | missing `first_paid_source`, `last_paid_source`, `first_click_id`, `last_click_id` |
| `/v0/top_sources` `by` | missing the `paid_source` option and its description |

The two files are byte-identical again.

## What was deliberately left alone

`StepFilterCondition` looks like the same bug and is not. It is the value of `FunnelStep.additionalProperties`, so the filtered column is the property key and the object carries only the comparison:

```json
"rdns": { "op": "eq", "value": "io.metamask" }
```

Its description now spells that out, because the `/v0/funnel` and `/v0/flow` `filters` arrays on the same page genuinely do use `{operand, operator, value}` and the two read alike. I changed this one first and reverted it after checking what actually references the schema.

## Also

Removed the 4 em dashes in the spec, per the writing-style rule in `CLAUDE.md`.

## Related

The matching backend change is getformo/formono#2101, which adds a CI guard pinning the documented property names to the Zod schemas that parse the request, so this class of drift fails the build instead of shipping. That guard is why this correction is unlikely to be needed twice.

This PR only describes the API as it already behaves, so it can merge independently of #2101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787731435&installation_model_id=21031&pr_number=119&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F119&signature=a49a9a28329ca30cdfe5b967f9ebe42ec2eb69be991a6b815277c5598fdd6811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->