### PR TITLE
Document filter membership delimiter

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2229,7 +2229,7 @@
       "AnalyticsFilters": {
         "name": "filters",
         "in": "query",
-        "description": "Array of filter conditions, JSON-encoded in the query string. Entries use `{ field, op, value }` and are combined with implicit AND. For example, filter traffic referred by Google with `[{\"field\":\"referrer\",\"op\":\"contains\",\"value\":\"google\"}]`, or filter a page with `[{\"field\":\"page\",\"op\":\"eq\",\"value\":\"/pricing\"}]`. Use `in` / `nin` with a pipe-delimited `value` (e.g. `\"chrome|firefox\"`) for multi-value matching.",
+        "description": "Array of filter conditions, JSON-encoded in the query string. Entries use `{ field, op, value }` and are combined with implicit AND. For example, filter traffic referred by Google with `[{\"field\":\"referrer\",\"op\":\"contains\",\"value\":\"google\"}]`, or filter a page with `[{\"field\":\"page\",\"op\":\"eq\",\"value\":\"/pricing\"}]`. For `in` / `nin`, pass an array value such as `[\"chrome\",\"firefox\"]` or a pipe-delimited string such as `\"chrome|firefox\"`. Array string members cannot contain a literal `|`, which is reserved as the Tinybird membership separator. Optional one-level nested `filters` use the same canonical envelope and membership rule.",
         "schema": {
           "type": "string"
         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -290,7 +290,8 @@
                 "items": {
                   "oneOf": [
                     {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "^[^|]*$"
                     },
                     {
                       "type": "number"
@@ -302,7 +303,7 @@
                 "type": "null"
               }
             ],
-            "description": "Value to compare against. Omit for `notEmpty` and `isEmpty`. For `in` / `nin`, pass an array or a pipe-delimited string."
+            "description": "Value to compare against. Omit for `notEmpty` and `isEmpty`. For `in` / `nin`, pass an array or a pipe-delimited string. Array string members cannot contain a literal `|`, which is reserved as the Tinybird membership separator."
           }
         },
         "required": [
@@ -408,7 +409,8 @@
                 "items": {
                   "oneOf": [
                     {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "^[^|]*$"
                     },
                     {
                       "type": "number"
@@ -420,7 +422,7 @@
                 "type": "null"
               }
             ],
-            "description": "Value to compare against. Omit for `notEmpty` and `isEmpty`. For `in` / `nin`, pass an array or a pipe-delimited string."
+            "description": "Value to compare against. Omit for `notEmpty` and `isEmpty`. For `in` / `nin`, pass an array or a pipe-delimited string. Array string members cannot contain a literal `|`, which is reserved as the Tinybird membership separator."
           },
           "filters": {
             "type": "array",
@@ -478,7 +480,8 @@
                 "items": {
                   "oneOf": [
                     {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "^[^|]*$"
                     },
                     {
                       "type": "number"
@@ -490,7 +493,7 @@
                 "type": "null"
               }
             ],
-            "description": "Value to compare against. Omit for `notEmpty` and `isEmpty`. For `in` / `nin`, pass an array or a pipe-delimited string."
+            "description": "Value to compare against. Omit for `notEmpty` and `isEmpty`. For `in` / `nin`, pass an array or a pipe-delimited string. Array string members cannot contain a literal `|`, which is reserved as the Tinybird membership separator."
           }
         },
         "required": [
@@ -541,7 +544,8 @@
                 "items": {
                   "oneOf": [
                     {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "^[^|]*$"
                     },
                     {
                       "type": "number"
@@ -552,7 +556,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Value to compare against. Omit for `notEmpty` and `isEmpty`. Array string members cannot contain a literal `|`, which is reserved as the Tinybird membership separator."
           }
         },
         "required": [


### PR DESCRIPTION
## What changed

- Documents that string members in filter membership arrays cannot contain a literal pipe.
- Adds OpenAPI patterns for step, analytics, nested analytics, and segment filter array members.
- Keeps the docs OpenAPI byte-identical to Formono commit `1094b033e`.

## Why

Tinybird membership filters use a plain pipe-delimited scalar internally. Rejecting an unrepresentable literal pipe prevents a documented array from being decoded as extra members and returning an incorrect cohort.

## Validation

- OpenAPI JSON parses successfully.
- No em or en dashes are present.
- File SHA-256 matches `apps/backend/src/openapi.json` in Formono.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787900823&installation_model_id=21031&pr_number=122&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F122&signature=2b37fb60b24b9612a023c20b66dfeac6b04d630b081559e908d8cbf3ec103c28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->