### PR TITLE
Document canonical User Paths and retention settings

### DIFF
--- a/api/boards/create-chart.mdx
+++ b/api/boards/create-chart.mdx
@@ -8,7 +8,7 @@ openapi: "POST /v0/boards/{boardId}/charts"
 
 Creates a new chart and attaches it to a board. Returns the full chart object on success.
 
-The `chart_type` field controls which other request body fields are required or validated. Funnel charts are special - their SQL is **auto-generated** from the `steps` array, so pass `"SELECT 1"` as the `query` placeholder.
+The `chart_type` field controls which other request body fields are required or validated. Funnel charts derive SQL from `steps` and accept `"SELECT 1"` as the placeholder. User Paths charts derive SQL from `settings.anchors`, so omit `query`.
 
 ---
 
@@ -17,7 +17,7 @@ The `chart_type` field controls which other request body fields are required or 
 | Field         | Type          | Required    | Description                                                                                     |
 | ------------- | ------------- | ----------- | ----------------------------------------------------------------------------------------------- |
 | `projectId`   | string        | Yes         | Project the chart belongs to                                                                    |
-| `query`       | string        | Conditional | SQL query. Required for all types except `retention`. For `funnel`, pass `"SELECT 1"`           |
+| `query`       | string        | Conditional | SQL query. Omit for `user_paths` and `retention`. For `funnel`, pass `"SELECT 1"`               |
 | `chart_type`  | string        | Yes         | `table` · `number` · `bar` · `line` · `area` · `pie` · `stacked` · `funnel` · `user_paths` · `retention` |
 | `title`       | string        | Yes         | Display name (minimum 1 character)                                                              |
 | `description` | string        | No          | Optional description                                                                            |
@@ -397,7 +397,7 @@ For all-user retention with no event filters, explicitly set both event filters 
 | `pie`        | `y_axis` requires exactly 1 element                                                      |
 | `stacked`    | `x_axis` required; `y_axis` requires exactly 1 element; `group_by` required              |
 | `funnel`     | `steps` requires ≥ 2 `FunnelStep` objects; `query` must be `"SELECT 1"` or any valid SQL |
-| `user_paths` | `settings.anchors` requires at least one entry; `query` must execute and return valid path data |
+| `user_paths` | `settings.anchors` requires at least one entry; the query is generated from the anchors |
 | `retention`  | `settings.entryFilter` key is required; `query` is ignored                                  |
 
 ---
@@ -436,7 +436,7 @@ Use the returned `id` with the [Get Chart](/api/boards/get-chart), [Update Chart
 
 Creates a new chart and attaches it to a board. Returns the full chart object on success.
 
-The `chart_type` field controls which other request body fields are required or validated. Funnel charts are special - their SQL is **auto-generated** from the `steps` array, so pass `"SELECT 1"` as the `query` placeholder.
+The `chart_type` field controls which other request body fields are required or validated. Funnel charts derive SQL from `steps` and accept `"SELECT 1"` as the placeholder. User Paths charts derive SQL from `settings.anchors`, so omit `query`.
 
 ---
 
@@ -445,7 +445,7 @@ The `chart_type` field controls which other request body fields are required or 
 | Field         | Type          | Required    | Description                                                                                     |
 | ------------- | ------------- | ----------- | ----------------------------------------------------------------------------------------------- |
 | `projectId`   | string        | Yes         | Project the chart belongs to                                                                    |
-| `query`       | string        | Conditional | SQL query. Required for all types except `retention`. For `funnel`, pass `"SELECT 1"`           |
+| `query`       | string        | Conditional | SQL query. Omit for `user_paths` and `retention`. For `funnel`, pass `"SELECT 1"`               |
 | `chart_type`  | string        | Yes         | `table` · `number` · `bar` · `line` · `area` · `pie` · `stacked` · `funnel` · `user_paths` · `retention` |
 | `title`       | string        | Yes         | Display name (minimum 1 character)                                                              |
 | `description` | string        | No          | Optional description                                                                            |
@@ -825,7 +825,7 @@ For all-user retention with no event filters, explicitly set both event filters 
 | `pie`        | `y_axis` requires exactly 1 element                                                                                                                    |
 | `stacked`    | `x_axis` required; `y_axis` requires exactly 1 element; `group_by` required                                                                            |
 | `funnel`     | `steps` requires ≥ 2 `FunnelStep` objects; `query` must be `"SELECT 1"` or any valid SQL                                                               |
-| `user_paths` | `settings.anchors` requires at least one entry; `query` must execute and return data in the expected user-path format (columns: user identifier, event name, timestamp) |
+| `user_paths` | `settings.anchors` requires at least one entry; the query is generated from the anchors                                                   |
 | `retention`  | `settings.entryFilter` key is required; `query` is ignored                                                                                                                  |
 
 ---

--- a/api/boards/create-chart.mdx
+++ b/api/boards/create-chart.mdx
@@ -227,8 +227,10 @@ Filter step 2 to MetaMask wallets on Ethereum mainnet:
     {
       "type": "event",
       "event": "connect",
-      "rdns": { "op": "eq", "value": "io.metamask" },
-      "chain_id": { "op": "eq", "value": "1" }
+      "filters": [
+        { "field": "rdns", "op": "eq", "value": "io.metamask" },
+        { "field": "chain_id", "op": "eq", "value": "1" }
+      ]
     },
     { "type": "event", "event": "transaction" }
   ],
@@ -272,12 +274,18 @@ Filter step 2 to MetaMask wallets on Ethereum mainnet:
     {
       "type": "event",
       "event": "page",
-      "device": { "op": "eq", "value": "mobile" }
+      "filters": [{ "field": "device", "op": "eq", "value": "mobile" }]
     },
     {
       "type": "event",
       "event": "connect",
-      "provider_name": { "op": "in", "value": "metamask|rainbow|coinbase" }
+      "filters": [
+        {
+          "field": "provider_name",
+          "op": "in",
+          "value": ["metamask", "rainbow", "coinbase"]
+        }
+      ]
     },
     { "type": "event", "event": "transaction" }
   ],
@@ -293,18 +301,17 @@ Filter step 2 to MetaMask wallets on Ethereum mainnet:
 
 ## User Paths Charts
 
-Visualize how users navigate your app after a starting event. `settings.startStep` is required.
+Visualize how users navigate your app through an ordered list of path anchors. `settings.anchors` requires at least one entry. One anchor produces an open-ended exploration; two or more constrain the path in order.
 
 ### `settings` for User Paths Charts
 
-| Field              | Type                   | Default | Description                                                        |
-| ------------------ | ---------------------- | ------- | ------------------------------------------------------------------ |
-| `startStep`        | `FunnelStep`           | -       | **Required.** Event where the flow begins                          |
-| `endStep`          | `FunnelStep` \| `null` | `null`  | Optional ending event. `null` = open-ended                         |
-| `maxSteps`         | integer (2 to 5)       | `3`     | Max steps to show in the flow. Values above 5 are clamped to 5     |
-| `nodesPerStep`     | integer (2 to 8)       | `5`     | Max unique event nodes per step. Values above 8 are clamped to 8   |
-| `conversionWindow` | `ConversionWindow`     | -       | Time window to group the flow                                      |
-| `filters`          | string                 | -       | JSON-encoded string of additional path filters                     |
+| Field              | Type               | Default | Description                                                      |
+| ------------------ | ------------------ | ------- | ---------------------------------------------------------------- |
+| `anchors`          | `FunnelStep[]`     | -       | **Required.** Ordered path anchors; one entry is open-ended       |
+| `maxSteps`         | integer (2 to 5)   | `3`     | Max steps to show in the flow. Values above 5 are clamped to 5   |
+| `nodesPerStep`     | integer (2 to 8)   | `5`     | Max unique event nodes per step. Values above 8 are clamped to 8 |
+| `conversionWindow` | `ConversionWindow` | -       | Time window to group the flow                                    |
+| `filters`          | string             | -       | JSON-encoded string of additional path filters                   |
 
 ```json
 {
@@ -313,8 +320,10 @@ Visualize how users navigate your app after a starting event. `settings.startSte
   "chart_type": "user_paths",
   "title": "Post-Connect User Flow",
   "settings": {
-    "startStep": { "type": "event", "event": "connect" },
-    "endStep": { "type": "event", "event": "transaction" },
+    "anchors": [
+      { "type": "event", "event": "connect" },
+      { "type": "event", "event": "transaction" }
+    ],
     "maxSteps": 5,
     "conversionWindow": { "value": 2, "unit": "week" }
   }
@@ -329,10 +338,11 @@ Measures how often users return over time. The `query` field is not used - pass 
 
 ### `settings` for Retention Charts
 
-| Field                  | Type                    | Description                                                                     |
-| ---------------------- | ----------------------- | ------------------------------------------------------------------------------- |
-| `retentionFilter`      | `FunnelStep` \| `null`  | Event that qualifies a returning visit as "retained". `null` = any event counts |
-| `retentionUserFilters` | `RetentionUserFilter[]` | User-segment filters that narrow the retention cohort                           |
+| Field                  | Type                    | Description                                                                       |
+| ---------------------- | ----------------------- | --------------------------------------------------------------------------------- |
+| `entryFilter`          | `FunnelStep` \| `null`  | **Required key.** Event that enters the cohort; `null` means any event             |
+| `retentionFilter`      | `FunnelStep` \| `null`  | Event that qualifies a return as "retained"; `null` means any event                |
+| `retentionUserFilters` | `RetentionUserFilter[]` | User-segment filters that narrow the retention cohort                             |
 
 Each `RetentionUserFilter`:
 
@@ -349,6 +359,7 @@ Each `RetentionUserFilter`:
   "chart_type": "retention",
   "title": "Weekly Retention - Desktop Users",
   "settings": {
+    "entryFilter": { "type": "event", "event": "transaction" },
     "retentionFilter": { "type": "event", "event": "transaction" },
     "retentionUserFilters": [
       { "field": "device", "op": "eq", "value": "desktop" },
@@ -358,14 +369,18 @@ Each `RetentionUserFilter`:
 }
 ```
 
-For all-user retention with no filters, omit `settings`:
+For all-user retention with no event filters, explicitly set both event filters to `null`:
 
 ```json
 {
   "projectId": "proj_abc",
   "query": "",
   "chart_type": "retention",
-  "title": "Overall Retention"
+  "title": "Overall Retention",
+  "settings": {
+    "entryFilter": null,
+    "retentionFilter": null
+  }
 }
 ```
 
@@ -382,8 +397,8 @@ For all-user retention with no filters, omit `settings`:
 | `pie`        | `y_axis` requires exactly 1 element                                                      |
 | `stacked`    | `x_axis` required; `y_axis` requires exactly 1 element; `group_by` required              |
 | `funnel`     | `steps` requires ≥ 2 `FunnelStep` objects; `query` must be `"SELECT 1"` or any valid SQL |
-| `user_paths` | `settings.startStep` required; `query` must execute and return valid path data           |
-| `retention`  | No query validation - `query` is ignored                                                 |
+| `user_paths` | `settings.anchors` requires at least one entry; `query` must execute and return valid path data |
+| `retention`  | `settings.entryFilter` key is required; `query` is ignored                                  |
 
 ---
 
@@ -640,8 +655,10 @@ Filter step 2 to MetaMask wallet connections on Ethereum mainnet:
     {
       "type": "event",
       "event": "connect",
-      "rdns": { "op": "eq", "value": "io.metamask" },
-      "chain_id": { "op": "eq", "value": "1" }
+      "filters": [
+        { "field": "rdns", "op": "eq", "value": "io.metamask" },
+        { "field": "chain_id", "op": "eq", "value": "1" }
+      ]
     },
     { "type": "event", "event": "transaction" }
   ],
@@ -685,12 +702,18 @@ Filter step 2 to MetaMask wallet connections on Ethereum mainnet:
     {
       "type": "event",
       "event": "page",
-      "device": { "op": "eq", "value": "mobile" }
+      "filters": [{ "field": "device", "op": "eq", "value": "mobile" }]
     },
     {
       "type": "event",
       "event": "connect",
-      "provider_name": { "op": "in", "value": "metamask|rainbow|coinbase" }
+      "filters": [
+        {
+          "field": "provider_name",
+          "op": "in",
+          "value": ["metamask", "rainbow", "coinbase"]
+        }
+      ]
     },
     { "type": "event", "event": "transaction" }
   ],
@@ -706,18 +729,17 @@ Filter step 2 to MetaMask wallet connections on Ethereum mainnet:
 
 ## User Paths Charts
 
-Visualize how users navigate your app after a starting event. `settings.startStep` is required.
+Visualize how users navigate your app through an ordered list of path anchors. `settings.anchors` requires at least one entry. One anchor produces an open-ended exploration; two or more constrain the path in order.
 
 ### `settings` for User Paths Charts
 
-| Field              | Type                   | Default | Description                                                        |
-| ------------------ | ---------------------- | ------- | ------------------------------------------------------------------ |
-| `startStep`        | `FunnelStep`           | -       | **Required.** Event where the flow begins                          |
-| `endStep`          | `FunnelStep` \| `null` | `null`  | Optional ending event. `null` = open-ended                         |
-| `maxSteps`         | integer (2 to 5)       | `3`     | Max steps to show in the flow. Values above 5 are clamped to 5     |
-| `nodesPerStep`     | integer (2 to 8)       | `5`     | Max unique event nodes per step. Values above 8 are clamped to 8   |
-| `conversionWindow` | `ConversionWindow`     | 2 weeks | Time window to group the flow                                      |
-| `filters`          | string                 | -       | JSON-encoded string of additional path filters                     |
+| Field              | Type               | Default | Description                                                      |
+| ------------------ | ------------------ | ------- | ---------------------------------------------------------------- |
+| `anchors`          | `FunnelStep[]`     | -       | **Required.** Ordered path anchors; one entry is open-ended       |
+| `maxSteps`         | integer (2 to 5)   | `3`     | Max steps to show in the flow. Values above 5 are clamped to 5   |
+| `nodesPerStep`     | integer (2 to 8)   | `5`     | Max unique event nodes per step. Values above 8 are clamped to 8 |
+| `conversionWindow` | `ConversionWindow` | 2 weeks | Time window to group the flow                                    |
+| `filters`          | string             | -       | JSON-encoded string of additional path filters                   |
 
 ```json
 {
@@ -726,8 +748,10 @@ Visualize how users navigate your app after a starting event. `settings.startSte
   "chart_type": "user_paths",
   "title": "Post-Connect User Flow",
   "settings": {
-    "startStep": { "type": "event", "event": "connect" },
-    "endStep": { "type": "event", "event": "transaction" },
+    "anchors": [
+      { "type": "event", "event": "connect" },
+      { "type": "event", "event": "transaction" }
+    ],
     "maxSteps": 5,
     "conversionWindow": { "value": 2, "unit": "week" }
   }
@@ -742,10 +766,11 @@ Measures how often users return over time. The `query` field is not used - pass 
 
 ### `settings` for Retention Charts
 
-| Field                  | Type                    | Description                                                                     |
-| ---------------------- | ----------------------- | ------------------------------------------------------------------------------- |
-| `retentionFilter`      | `FunnelStep` \| `null`  | Event that qualifies a returning visit as "retained". `null` = any event counts |
-| `retentionUserFilters` | `RetentionUserFilter[]` | User-segment filters that narrow the retention cohort                           |
+| Field                  | Type                    | Description                                                                       |
+| ---------------------- | ----------------------- | --------------------------------------------------------------------------------- |
+| `entryFilter`          | `FunnelStep` \| `null`  | **Required key.** Event that enters the cohort; `null` means any event             |
+| `retentionFilter`      | `FunnelStep` \| `null`  | Event that qualifies a return as "retained"; `null` means any event                |
+| `retentionUserFilters` | `RetentionUserFilter[]` | User-segment filters that narrow the retention cohort                             |
 
 Each `RetentionUserFilter`:
 
@@ -762,6 +787,7 @@ Each `RetentionUserFilter`:
   "chart_type": "retention",
   "title": "Weekly Retention - Desktop Users",
   "settings": {
+    "entryFilter": { "type": "event", "event": "transaction" },
     "retentionFilter": { "type": "event", "event": "transaction" },
     "retentionUserFilters": [
       { "field": "device", "op": "eq", "value": "desktop" },
@@ -771,14 +797,18 @@ Each `RetentionUserFilter`:
 }
 ```
 
-For all-user retention with no filters, omit `settings`:
+For all-user retention with no event filters, explicitly set both event filters to `null`:
 
 ```json
 {
   "projectId": "proj_abc",
   "query": "",
   "chart_type": "retention",
-  "title": "Overall Retention"
+  "title": "Overall Retention",
+  "settings": {
+    "entryFilter": null,
+    "retentionFilter": null
+  }
 }
 ```
 
@@ -795,8 +825,8 @@ For all-user retention with no filters, omit `settings`:
 | `pie`        | `y_axis` requires exactly 1 element                                                                                                                    |
 | `stacked`    | `x_axis` required; `y_axis` requires exactly 1 element; `group_by` required                                                                            |
 | `funnel`     | `steps` requires ≥ 2 `FunnelStep` objects; `query` must be `"SELECT 1"` or any valid SQL                                                               |
-| `user_paths` | `settings.startStep` required; `query` must execute and return data in the expected user-path format (columns: user identifier, event name, timestamp) |
-| `retention`  | No query validation - `query` is ignored                                                                                                               |
+| `user_paths` | `settings.anchors` requires at least one entry; `query` must execute and return data in the expected user-path format (columns: user identifier, event name, timestamp) |
+| `retention`  | `settings.entryFilter` key is required; `query` is ignored                                                                                                                  |
 
 ---
 

--- a/api/boards/create-chart.mdx
+++ b/api/boards/create-chart.mdx
@@ -316,7 +316,6 @@ Visualize how users navigate your app through an ordered list of path anchors. `
 ```json
 {
   "projectId": "proj_abc",
-  "query": "SELECT anonymous_id, type AS event, timestamp FROM events WHERE timestamp >= today() - INTERVAL 30 DAY ORDER BY anonymous_id, timestamp",
   "chart_type": "user_paths",
   "title": "Post-Connect User Flow",
   "settings": {
@@ -744,7 +743,6 @@ Visualize how users navigate your app through an ordered list of path anchors. `
 ```json
 {
   "projectId": "proj_abc",
-  "query": "SELECT anonymous_id, type AS event, timestamp FROM events WHERE timestamp >= today() - INTERVAL 30 DAY ORDER BY anonymous_id, timestamp",
   "chart_type": "user_paths",
   "title": "Post-Connect User Flow",
   "settings": {

--- a/api/boards/create-chart.mdx
+++ b/api/boards/create-chart.mdx
@@ -333,7 +333,7 @@ Visualize how users navigate your app through an ordered list of path anchors. `
 
 ## Retention Charts
 
-Measures how often users return over time. The `query` field is not used - pass `""` or omit it.
+Measures how often users return over time. Omit the `query` field; retention data is fetched automatically.
 
 ### `settings` for Retention Charts
 
@@ -354,7 +354,6 @@ Each `RetentionUserFilter`:
 ```json
 {
   "projectId": "proj_abc",
-  "query": "",
   "chart_type": "retention",
   "title": "Weekly Retention - Desktop Users",
   "settings": {
@@ -373,7 +372,6 @@ For all-user retention with no event filters, explicitly set both event filters 
 ```json
 {
   "projectId": "proj_abc",
-  "query": "",
   "chart_type": "retention",
   "title": "Overall Retention",
   "settings": {
@@ -397,7 +395,7 @@ For all-user retention with no event filters, explicitly set both event filters 
 | `stacked`    | `x_axis` required; `y_axis` requires exactly 1 element; `group_by` required              |
 | `funnel`     | `steps` requires ≥ 2 `FunnelStep` objects; `query` must be `"SELECT 1"` or any valid SQL |
 | `user_paths` | `settings.anchors` requires at least one entry; the query is generated from the anchors |
-| `retention`  | `settings.entryFilter` key is required; `query` is ignored                                  |
+| `retention`  | `settings.entryFilter` key is required; omit `query`                                       |
 
 ---
 
@@ -760,7 +758,7 @@ Visualize how users navigate your app through an ordered list of path anchors. `
 
 ## Retention Charts
 
-Measures how often users return over time. The `query` field is not used - pass `""` or omit it.
+Measures how often users return over time. Omit the `query` field; retention data is fetched automatically.
 
 ### `settings` for Retention Charts
 
@@ -781,7 +779,6 @@ Each `RetentionUserFilter`:
 ```json
 {
   "projectId": "proj_abc",
-  "query": "",
   "chart_type": "retention",
   "title": "Weekly Retention - Desktop Users",
   "settings": {
@@ -800,7 +797,6 @@ For all-user retention with no event filters, explicitly set both event filters 
 ```json
 {
   "projectId": "proj_abc",
-  "query": "",
   "chart_type": "retention",
   "title": "Overall Retention",
   "settings": {
@@ -824,7 +820,7 @@ For all-user retention with no event filters, explicitly set both event filters 
 | `stacked`    | `x_axis` required; `y_axis` requires exactly 1 element; `group_by` required                                                                            |
 | `funnel`     | `steps` requires ≥ 2 `FunnelStep` objects; `query` must be `"SELECT 1"` or any valid SQL                                                               |
 | `user_paths` | `settings.anchors` requires at least one entry; the query is generated from the anchors                                                   |
-| `retention`  | `settings.entryFilter` key is required; `query` is ignored                                                                                                                  |
+| `retention`  | `settings.entryFilter` key is required; omit `query`                                                                                                                       |
 
 ---
 

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -684,7 +684,7 @@
       },
       "ChartSettings": {
         "type": "object",
-        "description": "Chart-type-specific configuration. The fields that apply depend on `chart_type`:\n\n- **funnel**: `funnelType`, `conversionWindow`, `breakdown`\n- **user_paths**: `startStep`, `endStep`, `maxSteps`, `nodesPerStep`, `conversionWindow`, `filters`\n- **retention**: `retentionFilter`, `retentionUserFilters`, `retentionSignalType`, `retentionLabelSignal`\n\nAll fields are optional at the schema level; see per-type validation rules for which are functionally required.",
+        "description": "Chart-type-specific configuration. The fields that apply depend on `chart_type`:\n\n- **funnel**: `funnelType`, `conversionWindow`, `breakdown`\n- **user_paths**: `anchors`, `maxSteps`, `nodesPerStep`, `conversionWindow`, `filters`\n- **retention**: `entryFilter`, `retentionFilter`, `retentionUserFilters`, `retentionSignalType`, `retentionLabelSignal`\n\nFields are optional at the schema level except where the selected chart type requires them. User Paths require at least one `anchors` entry. Retention requests must explicitly include `entryFilter`; use `null` for any event.",
         "properties": {
           "funnelType": {
             "type": "string",
@@ -717,20 +717,13 @@
             ],
             "description": "**Funnel only.** Split each funnel bar by this dimension. The top categories are shown individually; the rest are collapsed into 'Others'."
           },
-          "startStep": {
-            "$ref": "#/components/schemas/FunnelStep",
-            "description": "**user_paths (required).** The event where the user flow begins."
-          },
-          "endStep": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/FunnelStep"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "**user_paths (optional).** The event where the user flow ends. If `null` the flow is open-ended."
+          "anchors": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/FunnelStep"
+            },
+            "description": "**user_paths (required).** Ordered path anchors. The first entry starts the flow; the last entry ends it. A single entry creates an open-ended flow."
           },
           "maxSteps": {
             "type": "integer",
@@ -760,6 +753,17 @@
               }
             ],
             "description": "**retention.** Event that qualifies a returning visit as 'retained'. If `null`, any event counts as a return."
+          },
+          "entryFilter": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FunnelStep"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "**retention (required).** Event that places a user into the cohort. If `null`, any event counts as cohort entry. The key must be present even when its value is `null`."
           },
           "retentionUserFilters": {
             "type": "array",
@@ -817,7 +821,7 @@
               "user_paths",
               "retention"
             ],
-            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.startStep` |\n| `retention` | none (`query` ignored) |"
+            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.anchors` (≥ 1) |\n| `retention` | `settings.entryFilter` (key required; `null` means any event) |"
           },
           "title": {
             "type": "string",
@@ -849,7 +853,7 @@
               "$ref": "#/components/schemas/FunnelStep"
             },
             "minItems": 2,
-            "description": "Ordered list of funnel steps. Required for `funnel` (minimum 2 steps).\n\nEach element is a `FunnelStep`; add property filters as extra keys on the step object (e.g. `\"rdns\": { \"op\": \"eq\", \"value\": \"io.metamask\" }`)."
+            "description": "Ordered list of funnel steps. Required for `funnel` (minimum 2 steps).\n\nEach element is a `FunnelStep`; add property predicates in its canonical `filters` array (e.g. `\"filters\": [{ \"field\": \"rdns\", \"op\": \"eq\", \"value\": \"io.metamask\" }]`)."
           },
           "settings": {
             "$ref": "#/components/schemas/ChartSettings"
@@ -892,7 +896,7 @@
               "user_paths",
               "retention"
             ],
-            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.startStep` |\n| `retention` | none (`query` ignored) |"
+            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.anchors` (≥ 1) |\n| `retention` | `settings.entryFilter` (key required; `null` means any event) |"
           },
           "title": {
             "type": "string",
@@ -924,7 +928,7 @@
               "$ref": "#/components/schemas/FunnelStep"
             },
             "minItems": 2,
-            "description": "Ordered list of funnel steps. Required for `funnel` (minimum 2 steps).\n\nEach element is a `FunnelStep`; add property filters as extra keys on the step object (e.g. `\"rdns\": { \"op\": \"eq\", \"value\": \"io.metamask\" }`)."
+            "description": "Ordered list of funnel steps. Required for `funnel` (minimum 2 steps).\n\nEach element is a `FunnelStep`; add property predicates in its canonical `filters` array (e.g. `\"filters\": [{ \"field\": \"rdns\", \"op\": \"eq\", \"value\": \"io.metamask\" }]`)."
           },
           "settings": {
             "$ref": "#/components/schemas/ChartSettings"
@@ -3855,14 +3859,16 @@
                     "chart_type": "user_paths",
                     "title": "Post-Connect User Flow",
                     "settings": {
-                      "startStep": {
-                        "type": "event",
-                        "event": "connect"
-                      },
-                      "endStep": {
-                        "type": "event",
-                        "event": "transaction"
-                      },
+                      "anchors": [
+                        {
+                          "type": "event",
+                          "event": "connect"
+                        },
+                        {
+                          "type": "event",
+                          "event": "transaction"
+                        }
+                      ],
                       "maxSteps": 5,
                       "conversionWindow": {
                         "value": 2,
@@ -3879,10 +3885,12 @@
                     "chart_type": "user_paths",
                     "title": "User Discovery Paths",
                     "settings": {
-                      "startStep": {
-                        "type": "event",
-                        "event": "page"
-                      },
+                      "anchors": [
+                        {
+                          "type": "event",
+                          "event": "page"
+                        }
+                      ],
                       "maxSteps": 5,
                       "nodesPerStep": 8
                     }
@@ -3897,6 +3905,10 @@
                     "title": "Weekly Retention: Desktop",
                     "settings": {
                       "retentionFilter": {
+                        "type": "event",
+                        "event": "transaction"
+                      },
+                      "entryFilter": {
                         "type": "event",
                         "event": "transaction"
                       },
@@ -3916,7 +3928,11 @@
                     "projectId": "proj_abc",
                     "query": "",
                     "chart_type": "retention",
-                    "title": "Overall Retention"
+                    "title": "Overall Retention",
+                    "settings": {
+                      "retentionFilter": null,
+                      "entryFilter": null
+                    }
                   }
                 }
               }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -805,7 +805,7 @@
           "query": {
             "type": "string",
             "minLength": 1,
-            "description": "SQL query that powers the chart.\n\n- **`funnel`**: pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`retention`**: can be omitted or pass `\"\"`; data is fetched automatically.\n- **All other types**: required; must be a valid SQL string."
+            "description": "SQL query that powers the chart.\n\n- **`funnel`**: pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`user_paths`**: omit it; the query is generated from `settings.anchors`.\n- **`retention`**: can be omitted or pass `\"\"`; data is fetched automatically.\n- **All other types**: required; must be a valid SQL string."
           },
           "chart_type": {
             "type": "string",
@@ -821,7 +821,7 @@
               "user_paths",
               "retention"
             ],
-            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.anchors` (≥ 1) |\n| `retention` | `settings.entryFilter` (key required; `null` means any event) |"
+            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `settings.anchors` (≥ 1); query is generated |\n| `retention` | `settings.entryFilter` (key required; `null` means any event) |"
           },
           "title": {
             "type": "string",
@@ -880,7 +880,7 @@
           "query": {
             "type": "string",
             "minLength": 1,
-            "description": "SQL query that powers the chart.\n\n- **`funnel`**: pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`retention`**: can be omitted or pass `\"\"`; data is fetched automatically.\n- **All other types**: required; must be a valid SQL string."
+            "description": "SQL query that powers the chart.\n\n- **`funnel`**: pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`user_paths`**: omit it; the query is generated from `settings.anchors`.\n- **`retention`**: can be omitted or pass `\"\"`; data is fetched automatically.\n- **All other types**: required; must be a valid SQL string."
           },
           "chart_type": {
             "type": "string",
@@ -896,7 +896,7 @@
               "user_paths",
               "retention"
             ],
-            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `query`, `settings.anchors` (≥ 1) |\n| `retention` | `settings.entryFilter` (key required; `null` means any event) |"
+            "description": "Visualization type. Determines which other fields are required:\n\n| `chart_type` | Extra required fields |\n|---|---|\n| `table` | `query` |\n| `number` | `query` (must return 1 row × 1 column) |\n| `bar` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `line` | `query`, `x_axis`, `y_axis` (≥ 1) |\n| `area` | `query`, `x_axis`, `y_axis` (≥ 1; exactly 1 if `group_by` set) |\n| `pie` | `query`, `y_axis` (exactly 1) |\n| `stacked` | `query`, `x_axis`, `y_axis` (exactly 1), `group_by` |\n| `funnel` | `steps` (≥ 2), `query` placeholder `\"SELECT 1\"` |\n| `user_paths` | `settings.anchors` (≥ 1); query is generated |\n| `retention` | `settings.entryFilter` (key required; `null` means any event) |"
           },
           "title": {
             "type": "string",
@@ -3687,14 +3687,18 @@
                       {
                         "type": "event",
                         "event": "connect",
-                        "rdns": {
-                          "op": "eq",
-                          "value": "io.metamask"
-                        },
-                        "chain_id": {
-                          "op": "eq",
-                          "value": "1"
-                        }
+                        "filters": [
+                          {
+                            "field": "rdns",
+                            "op": "eq",
+                            "value": "io.metamask"
+                          },
+                          {
+                            "field": "chain_id",
+                            "op": "eq",
+                            "value": "1"
+                          }
+                        ]
                       },
                       {
                         "type": "event",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3756,18 +3756,28 @@
                       {
                         "type": "event",
                         "event": "page",
-                        "device": {
-                          "op": "eq",
-                          "value": "mobile"
-                        }
+                        "filters": [
+                          {
+                            "field": "device",
+                            "op": "eq",
+                            "value": "mobile"
+                          }
+                        ]
                       },
                       {
                         "type": "event",
                         "event": "connect",
-                        "provider_name": {
-                          "op": "in",
-                          "value": "metamask|rainbow|coinbase"
-                        }
+                        "filters": [
+                          {
+                            "field": "provider_name",
+                            "op": "in",
+                            "value": [
+                              "metamask",
+                              "rainbow",
+                              "coinbase"
+                            ]
+                          }
+                        ]
                       },
                       {
                         "type": "event",
@@ -3859,7 +3869,6 @@
                   "summary": "User flow from connect (max 5 steps)",
                   "value": {
                     "projectId": "proj_abc",
-                    "query": "SELECT anonymous_id, type AS event, timestamp FROM events WHERE timestamp >= today() - INTERVAL 30 DAY ORDER BY anonymous_id, timestamp",
                     "chart_type": "user_paths",
                     "title": "Post-Connect User Flow",
                     "settings": {
@@ -3885,7 +3894,6 @@
                   "summary": "Open-ended user flow from page view",
                   "value": {
                     "projectId": "proj_abc",
-                    "query": "SELECT anonymous_id, type AS event, timestamp FROM events WHERE timestamp >= today() - INTERVAL 14 DAY ORDER BY anonymous_id, timestamp",
                     "chart_type": "user_paths",
                     "title": "User Discovery Paths",
                     "settings": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -805,7 +805,7 @@
           "query": {
             "type": "string",
             "minLength": 1,
-            "description": "SQL query that powers the chart.\n\n- **`funnel`**: pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`user_paths`**: omit it; the query is generated from `settings.anchors`.\n- **`retention`**: can be omitted or pass `\"\"`; data is fetched automatically.\n- **All other types**: required; must be a valid SQL string."
+            "description": "SQL query that powers the chart.\n\n- **`funnel`**: pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`user_paths`**: omit it; the query is generated from `settings.anchors`.\n- **`retention`**: omit it; data is fetched automatically.\n- **All other types**: required; must be a valid SQL string."
           },
           "chart_type": {
             "type": "string",
@@ -880,7 +880,7 @@
           "query": {
             "type": "string",
             "minLength": 1,
-            "description": "SQL query that powers the chart.\n\n- **`funnel`**: pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`user_paths`**: omit it; the query is generated from `settings.anchors`.\n- **`retention`**: can be omitted or pass `\"\"`; data is fetched automatically.\n- **All other types**: required; must be a valid SQL string."
+            "description": "SQL query that powers the chart.\n\n- **`funnel`**: pass `\"SELECT 1\"`; the actual query is auto-generated from `steps`.\n- **`user_paths`**: omit it; the query is generated from `settings.anchors`.\n- **`retention`**: omit it; data is fetched automatically.\n- **All other types**: required; must be a valid SQL string."
           },
           "chart_type": {
             "type": "string",
@@ -3912,7 +3912,6 @@
                   "summary": "Weekly retention: desktop users, transaction event",
                   "value": {
                     "projectId": "proj_abc",
-                    "query": "",
                     "chart_type": "retention",
                     "title": "Weekly Retention: Desktop",
                     "settings": {
@@ -3938,7 +3937,6 @@
                   "summary": "Overall retention (no filters)",
                   "value": {
                     "projectId": "proj_abc",
-                    "query": "",
                     "chart_type": "retention",
                     "title": "Overall Retention",
                     "settings": {

--- a/cli/charts.mdx
+++ b/cli/charts.mdx
@@ -96,8 +96,8 @@ Requires `boards:write` scope on your API key.
 | `--x-axis` | `string` | ❌ | Column used as the x-axis |
 | `--y-axis` | `string` | ❌ | Comma-separated or JSON array of y-axis columns |
 | `--group-by` | `string` | ❌ | Column used to group or stack series |
-| `--steps` | `string` | ❌ | JSON array of funnel/user-path step objects |
-| `--settings` | `string` | ❌ | JSON object of chart settings |
+| `--steps` | `string` | ❌ | JSON array of funnel step objects |
+| `--settings` | `string` | ❌ | JSON chart settings. User Paths require `anchors`; retention requires an `entryFilter` key. |
 
 Provide either `--body` or typed chart fields such as `--title`, `--chart-type`, and `--query`.
 
@@ -117,6 +117,13 @@ formo charts create \
 formo charts create \
   --board-id board_abc123 \
   --body '{"title":"Recent events","chart_type":"table","query":"SELECT * FROM events LIMIT 10"}'
+
+# Create an open-ended User Paths chart; omit --query
+formo charts create \
+  --board-id board_abc123 \
+  --title "Post-connect paths" \
+  --chart-type user_paths \
+  --settings '{"anchors":[{"type":"event","event":"connect"}],"maxSteps":5,"nodesPerStep":3}'
 ```
 
 ---


### PR DESCRIPTION
## Summary

- sync `api/openapi.json` byte-for-byte with the formono backend spec
- document User Paths with canonical `settings.anchors` instead of `startStep` / `endStep`
- document the required retention `entryFilter` key, including explicit `null` semantics
- update funnel step examples to use canonical `filters: [{ field, op, value }]` arrays

## Why

P-2386 removes the final runtime chart-settings compatibility readers. The public docs must describe the canonical persisted/request shapes so new callers do not recreate retired settings.

## Validation

- `cmp` confirms both OpenAPI files are byte-identical
- neither OpenAPI file contains em dashes
- `pnpm run validate` passes (the validator also reports an unrelated pre-existing parse diagnostic from the untracked local `changelog-2026-07-27.md`, which is not included in this PR)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787924757&installation_model_id=21031&pr_number=124&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F124&signature=122a9859de84dddf22739dce9cb3f9395e1c7bd80847f1965de293bf32c0446c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->