### PR TITLE
Document the Solana path for native connect events

### DIFF
--- a/data/events/connect.mdx
+++ b/data/events/connect.mdx
@@ -10,7 +10,7 @@ The `connect` event is emitted whenever the user connects a wallet.
 | Property | Type | Description |
 |:---------|:-----|:------------|
 | `chain_id` | Number | Chain ID of the network the wallet connected to. |
-| `provider_name` | String | Wallet connector/provider name (auto-captured through the wagmi and framework-kit integrations, or passed explicitly to `formo.connect()`). |
+| `provider_name` | String | Wallet connector/provider name (present when auto-captured through the wagmi integration). |
 
 ## Sample Payload
 
@@ -25,20 +25,3 @@ Here’s the payload of a typical call with most common fields removed:
     }
 }
 ```
-
-Solana connections use the same event type. Clusters map to reserved chain IDs above 900000 (`900001` is `mainnet-beta`); see [Solana integration](/sdks/web#solana-without-framework-kit).
-
-```json
-{
-    "type": "connect",
-    "address": "A5FLDA1NLmEfifFSB7xEKPc26dSbK5HTTsDhRTWqpDaJ",
-    "properties": {
-        "chain_id": 900001,
-        "provider_name": "Phantom"
-    }
-}
-```
-
-<Warning>
-Emit wallet connections with `formo.connect()`, not `formo.track()`. A custom track event named "Connect" is stored as a track event rather than the `connect` type, so the **Connect wallet** funnel step, first-time wallet connection charts, and wallet provider breakdowns will all be empty. See [Solana integration](/sdks/web#solana-integration) for how to emit it without an autocapture integration.
-</Warning>

--- a/data/events/connect.mdx
+++ b/data/events/connect.mdx
@@ -10,7 +10,7 @@ The `connect` event is emitted whenever the user connects a wallet.
 | Property | Type | Description |
 |:---------|:-----|:------------|
 | `chain_id` | Number | Chain ID of the network the wallet connected to. |
-| `provider_name` | String | Wallet connector/provider name (present when auto-captured through the wagmi integration). |
+| `provider_name` | String | Wallet connector/provider name (auto-captured through the wagmi and framework-kit integrations, or passed explicitly to `formo.connect()`). |
 
 ## Sample Payload
 
@@ -25,3 +25,20 @@ Here’s the payload of a typical call with most common fields removed:
     }
 }
 ```
+
+Solana connections use the same event type. Clusters map to reserved chain IDs above 900000 (`900001` is `mainnet-beta`); see [Solana integration](/sdks/web#solana-without-framework-kit).
+
+```json
+{
+    "type": "connect",
+    "address": "A5FLDA1NLmEfifFSB7xEKPc26dSbK5HTTsDhRTWqpDaJ",
+    "properties": {
+        "chain_id": 900001,
+        "provider_name": "Phantom"
+    }
+}
+```
+
+<Warning>
+Emit wallet connections with `formo.connect()`, not `formo.track()`. A custom track event named "Connect" is stored as a track event rather than the `connect` type, so the **Connect wallet** funnel step, first-time wallet connection charts, and wallet provider breakdowns will all be empty. See [Solana integration](/sdks/web#solana-integration) for how to emit it without an autocapture integration.
+</Warning>

--- a/install.mdx
+++ b/install.mdx
@@ -426,20 +426,25 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
 
         ```tsx
           import { createClient, autoDiscover } from '@solana/client';
+          import { SolanaProvider } from '@solana/react-hooks';
           import { FormoAnalyticsProvider } from '@formo/analytics';
 
           const client = createClient({
-            cluster: 'mainnet-beta',
+            cluster: 'mainnet',
             walletConnectors: autoDiscover(),
           });
 
-          <FormoAnalyticsProvider
-            writeKey="<YOUR_WRITE_KEY>"
-            options={{ evm: false, solana: { store: client.store } }}
-          >
-            <YourApp />
-          </FormoAnalyticsProvider>
+          <SolanaProvider client={client}>
+            <FormoAnalyticsProvider
+              writeKey="<YOUR_WRITE_KEY>"
+              options={{ evm: false, solana: { store: client.store } }}
+            >
+              <YourApp />
+            </FormoAnalyticsProvider>
+          </SolanaProvider>
         ```
+
+        Note the two spellings of mainnet: `@solana/client` takes `cluster: 'mainnet'`, while Formo's `SOLANA_CHAIN_IDS` is keyed on `'mainnet-beta'`.
       </Accordion>
       <Accordion title="wallet-adapter, Privy, Dynamic, Reown, or custom">
         There is no store to observe, so **nothing is autocaptured**. Emit wallet events yourself with [`connect`](/data/events/connect) and [`disconnect`](/data/events/disconnect).

--- a/install.mdx
+++ b/install.mdx
@@ -25,11 +25,14 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
 
   **Choose the right method based on the project:**
 
-  - **Wagmi (React)** - Recommended for apps with wallet connection (RainbowKit, ConnectKit, Reown, etc.)
+  - **Wagmi (React)** - Recommended for EVM apps with wallet connection (RainbowKit, ConnectKit, Reown, etc.)
   - **React (without Wagmi)** - For standalone React apps without Wagmi
   - **Next.js** - For Next.js apps (App Router or Pages Router). Requires a client component wrapper.
+  - **Solana** - For Solana apps. Wallet events are NOT autocaptured unless the app uses framework-kit.
 
   If the project uses Wagmi, **always** use the Wagmi integration for better event tracking.
+
+  If the project is a Solana app, **always** use Option E. The autocapture behaviour above applies to EVM wallets; on Solana it only applies when a framework-kit store is passed.
 
   If you're able to use a web tool to access a URL, visit https://docs.formo.so/install to get the latest, up-to-date instructions.
 
@@ -139,6 +142,45 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
     );
   }
 
+  ### **Option E: Solana**
+
+  npm install @formo/analytics --save
+
+  If the app uses framework-kit (`@solana/client`), pass the store and wallet events are autocaptured:
+
+  options={{ evm: false, solana: { store: client.store } }}
+
+  For ANY other Solana wallet library (`@solana/wallet-adapter`, Privy, Dynamic, Reown, custom), there is no store to observe and NOTHING is autocaptured. Initialize with options={{ evm: false }} and emit wallet events explicitly:
+
+  import { useEffect, useRef } from 'react';
+  import { useWallet } from '@solana/wallet-adapter-react';
+  import { useFormo, SOLANA_CHAIN_IDS } from '@formo/analytics';
+
+  const CHAIN_ID = SOLANA_CHAIN_IDS['mainnet-beta']; // 900001
+
+  function WalletTracking() {
+    const formo = useFormo();
+    const { publicKey, wallet, connected } = useWallet();
+    const lastAddress = useRef(null);
+
+    useEffect(() => {
+      if (!formo) return;
+      const address = publicKey?.toBase58() ?? null;
+      if (connected && address && address !== lastAddress.current) {
+        formo.connect({ chainId: CHAIN_ID, address }, { providerName: wallet?.adapter.name });
+        lastAddress.current = address;
+      }
+      if (!connected && lastAddress.current) {
+        formo.disconnect({ chainId: CHAIN_ID, address: lastAddress.current });
+        lastAddress.current = null;
+      }
+    }, [formo, connected, publicKey, wallet]);
+
+    return null;
+  }
+
+  Key: drive this from an effect on wallet state, not from the wallet modal's success handler, so restored sessions are counted. Solana clusters map to reserved chain IDs (`mainnet-beta` 900001, `testnet` 900002, `devnet` 900003, `localnet` 900004); use the `SOLANA_CHAIN_IDS` constant. Transactions and signatures always need explicit `formo.transaction()` and `formo.signature()` calls on Solana.
+
   ---
 
   ## **3. Identify Users & Track Events**
@@ -224,6 +266,8 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
   4. **Do not** use `<FormoAnalyticsProvider>` directly in `app/layout.tsx` - it needs a `'use client'` wrapper.
   5. **Do not** use `useFormo()` in Next.js Server Components - it only works in Client Components.
   6. **Do not** mix App Router (`app/layout.tsx`) and Pages Router (`pages/_app.tsx`) patterns.
+  7. **Do not** report wallet connections with `track()`. `formo.track('Connect', ...)` is stored as a custom track event, not the built-in `connect` type, so the Connect wallet funnel step and every wallet connection chart stay empty. Use `formo.connect()` / `formo.disconnect()`. This mistake is most common on Solana, where wallet events are not autocaptured outside framework-kit.
+  8. **Do not** assume wallet autocapture works on Solana. It only applies when a framework-kit store is passed via `options.solana.store`.
 
   ### **5.3: OUTDATED PATTERNS TO AVOID**
   // ❌ Wrong packages:
@@ -401,6 +445,8 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
 
     <Note>
     **Using Wagmi?** Install with [Wagmi](/sdks/web#wagmi) instead for better event tracking.
+
+    **Building on Solana?** Use the **Solana** tab instead. Wallet events are not autocaptured on this path for Solana wallets.
     </Note>
 
     #### 1. Install the Formo SDK
@@ -481,6 +527,8 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
 
     <Note>
     **Using Wagmi?** Install with [Wagmi](/sdks/web#wagmi) instead for better event tracking.
+
+    **Building on Solana?** Use the **Solana** tab instead. Wallet events are not autocaptured on this path for Solana wallets.
     </Note>
 
     #### 1. Install the Formo SDK
@@ -637,6 +685,118 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
     ```
 
   </Tab>
+  <Tab icon="circle-nodes" title="Solana">
+
+    <Note>
+    Full reference: [Solana integration](/sdks/web#solana-integration) on the Web SDK page.
+    </Note>
+
+    #### 1. Install the Formo SDK
+
+    ```bash
+      npm install @formo/analytics --save
+    ```
+
+    #### 2. Choose your integration path
+
+    How you set up depends on the wallet library your app uses.
+
+    <AccordionGroup>
+      <Accordion title="framework-kit (autocapture)">
+        Pass `client.store` and the SDK captures connects, disconnects, and cluster switches automatically.
+
+        ```tsx
+          import { createClient, autoDiscover } from '@solana/client';
+          import { FormoAnalyticsProvider } from '@formo/analytics';
+
+          const client = createClient({
+            cluster: 'mainnet-beta',
+            walletConnectors: autoDiscover(),
+          });
+
+          <FormoAnalyticsProvider
+            writeKey="<YOUR_WRITE_KEY>"
+            options={{ evm: false, solana: { store: client.store } }}
+          >
+            <YourApp />
+          </FormoAnalyticsProvider>
+        ```
+      </Accordion>
+      <Accordion title="wallet-adapter, Privy, Dynamic, Reown, or custom">
+        There is no store to observe, so **nothing is autocaptured**. Emit wallet events yourself with [`connect`](/data/events/connect) and [`disconnect`](/data/events/disconnect).
+
+        ```tsx
+          import { useEffect, useRef } from 'react';
+          import { useWallet } from '@solana/wallet-adapter-react';
+          import { useFormo, SOLANA_CHAIN_IDS } from '@formo/analytics';
+
+          const CHAIN_ID = SOLANA_CHAIN_IDS['mainnet-beta'];
+
+          function WalletTracking() {
+            const formo = useFormo();
+            const { publicKey, wallet, connected } = useWallet();
+            const lastAddress = useRef<string | null>(null);
+
+            useEffect(() => {
+              if (!formo) return;
+              const address = publicKey?.toBase58() ?? null;
+
+              if (connected && address && address !== lastAddress.current) {
+                formo.connect(
+                  { chainId: CHAIN_ID, address },
+                  { providerName: wallet?.adapter.name },
+                );
+                lastAddress.current = address;
+              }
+
+              if (!connected && lastAddress.current) {
+                formo.disconnect({ chainId: CHAIN_ID, address: lastAddress.current });
+                lastAddress.current = null;
+              }
+            }, [formo, connected, publicKey, wallet]);
+
+            return null;
+          }
+        ```
+
+        Render `<WalletTracking />` once inside your wallet provider. Driving it from an effect (rather than the wallet modal's success handler) means restored sessions are counted too.
+      </Accordion>
+    </AccordionGroup>
+
+    <Warning>
+    Do not report wallet connections with `track()`. A custom event such as `track('Connect', { address })` is stored as a track event, not the built-in `connect` type, so the **Connect wallet** funnel step, first-time wallet connection charts, and wallet provider breakdowns will all be empty. Use `connect()` for wallet connections and `track()` for product events.
+    </Warning>
+
+    #### 3. Identify users
+
+    Call [`identify`](/data/events/identify) once a wallet address is known.
+
+    ```tsx
+    import { useFormo } from "@formo/analytics";
+    import { useWallet } from "@solana/wallet-adapter-react";
+
+    const HomePage = () => {
+      const { publicKey } = useWallet();
+      const analytics = useFormo();
+
+      useEffect(() => {
+        const address = publicKey?.toBase58();
+        if (address && analytics) {
+          analytics.identify({ address });
+        }
+      }, [publicKey, analytics]);
+    }
+    ```
+
+    #### 4. Track custom events
+
+    Transactions and signatures need explicit [`transaction`](/data/events/transaction) and [`signature`](/data/events/signature) calls on both paths. For app-specific actions, use [`track`](/sdks/web#track-events).
+
+    ```tsx
+      analytics.track('Vault Deposit Completed', { vault_name: 'USD*', volume: 100 });
+    ```
+
+  </Tab>
   <Tab icon="angular" title="Angular">
 
     <Note>
@@ -790,6 +950,10 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
 
 The Formo SDK automatically captures key events (page views, sessions) and wallet events (connect, disconnect, signature, transaction) with full attribution data (channel, campaign, referrer, UTM, referrals.)
 
+<Note>
+Wallet event autocapture covers EVM wallets, and Solana wallets when your app uses [framework-kit](/sdks/web#solana-with-framework-kit). On any other Solana setup (`@solana/wallet-adapter`, Privy, Dynamic, Reown, or a custom connector) there is no wallet state for the SDK to observe, so you emit `connect` and `disconnect` yourself. See [Solana without framework-kit](/sdks/web#solana-without-framework-kit).
+</Note>
+
 ## Verification
 
 To verify that the SDK is installed correctly, navigate to your site and open the network tab of the developer tools in your browser.
@@ -816,7 +980,7 @@ This applies to every installation method above. If you use the HTML snippet, al
 
 <CardGroup>
   <Card title="Web SDK" icon="globe" iconType="regular" href="/sdks/web">
-    HTML, React, Next.js, Angular
+    HTML, React, Next.js, Solana, Angular
   </Card>
   <Card title="Mobile SDK" icon="mobile" iconType="regular" href="/sdks/mobile">
     React Native
@@ -830,7 +994,12 @@ This applies to every installation method above. If you use the HTML snippet, al
 
 <AccordionGroup>
   <Accordion title="Which installation method should I use?">
-    If your app uses [Wagmi](https://wagmi.sh/) for wallet connections and its hooks for transactions, use the [Wagmi integration](/sdks/web#wagmi). For React or Next.js apps without Wagmi, use the [React integration](/sdks/web#react--nextjs-without-wagmi). For static sites or non-React apps, use the [HTML snippet](/sdks/web#html-snippet). For mobile apps, use the [React Native SDK](/sdks/mobile).
+    If your app uses [Wagmi](https://wagmi.sh/) for wallet connections and its hooks for transactions, use the [Wagmi integration](/sdks/web#wagmi). For Solana apps, use the [Solana integration](/sdks/web#solana-integration). For React or Next.js apps without Wagmi, use the [React integration](/sdks/web#react--nextjs-without-wagmi). For static sites or non-React apps, use the [HTML snippet](/sdks/web#html-snippet). For mobile apps, use the [React Native SDK](/sdks/mobile).
+  </Accordion>
+  <Accordion title="Why are my Solana wallet connections not showing up?">
+    Wallet events are only autocaptured on Solana when your app passes a [framework-kit](/sdks/web#solana-with-framework-kit) store to `options.solana.store`. With `@solana/wallet-adapter`, Privy, Dynamic, Reown, or a custom connector there is nothing for the SDK to observe, so you emit them yourself with [`connect()`](/data/events/connect) and [`disconnect()`](/data/events/disconnect). See [Solana without framework-kit](/sdks/web#solana-without-framework-kit).
+
+    Sending connections as a custom `track()` event instead will not work: they are stored as track events rather than the `connect` type, so the **Connect wallet** funnel step and wallet connection charts stay empty.
   </Accordion>
   <Accordion title="How do I verify that the Formo SDK is installed correctly?">
     After installing the Formo SDK, visit your site and open the [Activity page](/features/product-analytics/activity) in the Formo dashboard. You should see your pageview appear under the most recent events. You can also check your browser's Network tab for requests to `events.formo.so` to inspect if events are sent successfully with a 2XX status code.

--- a/install.mdx
+++ b/install.mdx
@@ -7,7 +7,7 @@ icon: rocket-launch
 ## Install with AI
 
 <Tip>
-Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com/link/prompt?text=Install%20Formo%20Analytics%20using%20the%20instructions%20at%20https%3A%2F%2Fdocs.formo.so%2Finstall%20and%20https%3A%2F%2Fdocs.formo.so%2Fsdks%2Fweb.%20Detect%20the%20framework%20%28Wagmi%2C%20React%2C%20Next.js%29%20and%20follow%20the%20matching%20setup.%20Use%20%40formo%2Fanalytics%20as%20the%20only%20package.%20Wrap%20the%20app%20with%20FormoAnalyticsProvider.%20For%20Wagmi%2C%20place%20it%20inside%20WagmiProvider%20and%20QueryClientProvider%20and%20pass%20both%20config%20and%20queryClient%20via%20options.wagmi.%20For%20Next.js%20App%20Router%2C%20create%20a%20%27use%20client%27%20wrapper%20component.%20After%20setup%2C%20add%20identify%28%29%20after%20wallet%20connection%20and%20track%28%29%20for%20custom%20events.%20Analyze%20the%20codebase%20to%20suggest%20relevant%20custom%20events%20to%20track.)
+Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com/link/prompt?text=Install%20Formo%20Analytics%20using%20the%20instructions%20at%20https%3A%2F%2Fdocs.formo.so%2Finstall%20and%20https%3A%2F%2Fdocs.formo.so%2Fsdks%2Fweb.%20Detect%20the%20framework%20%28Wagmi%2C%20React%2C%20Next.js%2C%20Solana%29%20and%20follow%20the%20matching%20setup.%20Use%20%40formo%2Fanalytics%20as%20the%20only%20package.%20Wrap%20the%20app%20with%20FormoAnalyticsProvider.%20For%20Wagmi%2C%20place%20it%20inside%20WagmiProvider%20and%20QueryClientProvider%20and%20pass%20both%20config%20and%20queryClient%20via%20options.wagmi.%20For%20Next.js%20App%20Router%2C%20create%20a%20%27use%20client%27%20wrapper%20component.%20For%20Solana%2C%20wallet%20events%20are%20only%20autocaptured%20when%20a%20framework-kit%20store%20is%20passed%20via%20options.solana.store%3B%20with%20%40solana%2Fwallet-adapter%2C%20Privy%2C%20Dynamic%2C%20or%20Reown%20nothing%20is%20autocaptured%2C%20so%20call%20formo.connect%28%29%20and%20formo.disconnect%28%29%20from%20an%20effect%20on%20wallet%20state%2C%20and%20never%20report%20wallet%20connections%20with%20track%28%29.%20After%20setup%2C%20add%20identify%28%29%20after%20wallet%20connection%20and%20track%28%29%20for%20custom%20events.%20Analyze%20the%20codebase%20to%20suggest%20relevant%20custom%20events%20to%20track.)
 </Tip>
 
 <Accordion title="Copy prompt">
@@ -32,7 +32,7 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
 
   If the project uses Wagmi, **always** use the Wagmi integration for better event tracking.
 
-  If the project is a Solana app, **always** use Option E. The autocapture behaviour above applies to EVM wallets; on Solana it only applies when a framework-kit store is passed.
+  If the project is a Solana app, **always** use Option E. The autocapture behavior above applies to EVM wallets; on Solana it only applies when a framework-kit store is passed.
 
   If you're able to use a web tool to access a URL, visit https://docs.formo.so/install to get the latest, up-to-date instructions.
 
@@ -403,6 +403,114 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
 
       export default HomePage;
     ```
+  </Tab>
+  <Tab icon="circle-nodes" title="Solana">
+
+    <Note>
+    Full reference: [Solana integration](/sdks/web#solana-integration) on the Web SDK page.
+    </Note>
+
+    #### 1. Install the Formo SDK
+
+    ```bash
+      npm install @formo/analytics --save
+    ```
+
+    #### 2. Choose your integration path
+
+    How you set up depends on the wallet library your app uses.
+
+    <AccordionGroup>
+      <Accordion title="framework-kit (autocapture)">
+        Pass `client.store` and the SDK captures connects, disconnects, and cluster switches automatically.
+
+        ```tsx
+          import { createClient, autoDiscover } from '@solana/client';
+          import { FormoAnalyticsProvider } from '@formo/analytics';
+
+          const client = createClient({
+            cluster: 'mainnet-beta',
+            walletConnectors: autoDiscover(),
+          });
+
+          <FormoAnalyticsProvider
+            writeKey="<YOUR_WRITE_KEY>"
+            options={{ evm: false, solana: { store: client.store } }}
+          >
+            <YourApp />
+          </FormoAnalyticsProvider>
+        ```
+      </Accordion>
+      <Accordion title="wallet-adapter, Privy, Dynamic, Reown, or custom">
+        There is no store to observe, so **nothing is autocaptured**. Emit wallet events yourself with [`connect`](/data/events/connect) and [`disconnect`](/data/events/disconnect).
+
+        ```tsx
+          import { useEffect, useRef } from 'react';
+          import { useWallet } from '@solana/wallet-adapter-react';
+          import { useFormo, SOLANA_CHAIN_IDS } from '@formo/analytics';
+
+          const CHAIN_ID = SOLANA_CHAIN_IDS['mainnet-beta'];
+
+          function WalletTracking() {
+            const formo = useFormo();
+            const { publicKey, wallet, connected } = useWallet();
+            const lastAddress = useRef<string | null>(null);
+
+            useEffect(() => {
+              if (!formo) return;
+              const address = publicKey?.toBase58() ?? null;
+
+              if (connected && address && address !== lastAddress.current) {
+                formo.connect(
+                  { chainId: CHAIN_ID, address },
+                  { providerName: wallet?.adapter.name },
+                );
+                lastAddress.current = address;
+              }
+
+              if (!connected && lastAddress.current) {
+                formo.disconnect({ chainId: CHAIN_ID, address: lastAddress.current });
+                lastAddress.current = null;
+              }
+            }, [formo, connected, publicKey, wallet]);
+
+            return null;
+          }
+        ```
+
+        Render `<WalletTracking />` once inside your wallet provider. Driving it from an effect (rather than the wallet modal's success handler) means restored sessions are counted too.
+      </Accordion>
+    </AccordionGroup>
+
+    #### 3. Identify users
+
+    Call [`identify`](/data/events/identify) once a wallet address is known.
+
+    ```tsx
+    import { useFormo } from "@formo/analytics";
+    import { useWallet } from "@solana/wallet-adapter-react";
+
+    const HomePage = () => {
+      const { publicKey } = useWallet();
+      const analytics = useFormo();
+
+      useEffect(() => {
+        const address = publicKey?.toBase58();
+        if (address && analytics) {
+          analytics.identify({ address });
+        }
+      }, [publicKey, analytics]);
+    }
+    ```
+
+    #### 4. Track custom events
+
+    Transactions and signatures need explicit [`transaction`](/data/events/transaction) and [`signature`](/data/events/signature) calls on both paths. For app-specific actions, use [`track`](/sdks/web#track-events).
+
+    ```tsx
+      analytics.track('Vault Deposit Completed', { vault_name: 'USD*', volume: 100 });
+    ```
+
   </Tab>
   <Tab icon="code" title="HTML Snippet">
 
@@ -821,114 +929,6 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
         this.formo.track('Swap Completed', { volume: 100 });
       }
     }
-    ```
-
-  </Tab>
-  <Tab icon="circle-nodes" title="Solana">
-
-    <Note>
-    Full reference: [Solana integration](/sdks/web#solana-integration) on the Web SDK page.
-    </Note>
-
-    #### 1. Install the Formo SDK
-
-    ```bash
-      npm install @formo/analytics --save
-    ```
-
-    #### 2. Choose your integration path
-
-    How you set up depends on the wallet library your app uses.
-
-    <AccordionGroup>
-      <Accordion title="framework-kit (autocapture)">
-        Pass `client.store` and the SDK captures connects, disconnects, and cluster switches automatically.
-
-        ```tsx
-          import { createClient, autoDiscover } from '@solana/client';
-          import { FormoAnalyticsProvider } from '@formo/analytics';
-
-          const client = createClient({
-            cluster: 'mainnet-beta',
-            walletConnectors: autoDiscover(),
-          });
-
-          <FormoAnalyticsProvider
-            writeKey="<YOUR_WRITE_KEY>"
-            options={{ evm: false, solana: { store: client.store } }}
-          >
-            <YourApp />
-          </FormoAnalyticsProvider>
-        ```
-      </Accordion>
-      <Accordion title="wallet-adapter, Privy, Dynamic, Reown, or custom">
-        There is no store to observe, so **nothing is autocaptured**. Emit wallet events yourself with [`connect`](/data/events/connect) and [`disconnect`](/data/events/disconnect).
-
-        ```tsx
-          import { useEffect, useRef } from 'react';
-          import { useWallet } from '@solana/wallet-adapter-react';
-          import { useFormo, SOLANA_CHAIN_IDS } from '@formo/analytics';
-
-          const CHAIN_ID = SOLANA_CHAIN_IDS['mainnet-beta'];
-
-          function WalletTracking() {
-            const formo = useFormo();
-            const { publicKey, wallet, connected } = useWallet();
-            const lastAddress = useRef<string | null>(null);
-
-            useEffect(() => {
-              if (!formo) return;
-              const address = publicKey?.toBase58() ?? null;
-
-              if (connected && address && address !== lastAddress.current) {
-                formo.connect(
-                  { chainId: CHAIN_ID, address },
-                  { providerName: wallet?.adapter.name },
-                );
-                lastAddress.current = address;
-              }
-
-              if (!connected && lastAddress.current) {
-                formo.disconnect({ chainId: CHAIN_ID, address: lastAddress.current });
-                lastAddress.current = null;
-              }
-            }, [formo, connected, publicKey, wallet]);
-
-            return null;
-          }
-        ```
-
-        Render `<WalletTracking />` once inside your wallet provider. Driving it from an effect (rather than the wallet modal's success handler) means restored sessions are counted too.
-      </Accordion>
-    </AccordionGroup>
-
-    #### 3. Identify users
-
-    Call [`identify`](/data/events/identify) once a wallet address is known.
-
-    ```tsx
-    import { useFormo } from "@formo/analytics";
-    import { useWallet } from "@solana/wallet-adapter-react";
-
-    const HomePage = () => {
-      const { publicKey } = useWallet();
-      const analytics = useFormo();
-
-      useEffect(() => {
-        const address = publicKey?.toBase58();
-        if (address && analytics) {
-          analytics.identify({ address });
-        }
-      }, [publicKey, analytics]);
-    }
-    ```
-
-    #### 4. Track custom events
-
-    Transactions and signatures need explicit [`transaction`](/data/events/transaction) and [`signature`](/data/events/signature) calls on both paths. For app-specific actions, use [`track`](/sdks/web#track-events).
-
-    ```tsx
-      analytics.track('Vault Deposit Completed', { vault_name: 'USD*', volume: 100 });
     ```
 
   </Tab>

--- a/install.mdx
+++ b/install.mdx
@@ -685,118 +685,6 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
     ```
 
   </Tab>
-  <Tab icon="circle-nodes" title="Solana">
-
-    <Note>
-    Full reference: [Solana integration](/sdks/web#solana-integration) on the Web SDK page.
-    </Note>
-
-    #### 1. Install the Formo SDK
-
-    ```bash
-      npm install @formo/analytics --save
-    ```
-
-    #### 2. Choose your integration path
-
-    How you set up depends on the wallet library your app uses.
-
-    <AccordionGroup>
-      <Accordion title="framework-kit (autocapture)">
-        Pass `client.store` and the SDK captures connects, disconnects, and cluster switches automatically.
-
-        ```tsx
-          import { createClient, autoDiscover } from '@solana/client';
-          import { FormoAnalyticsProvider } from '@formo/analytics';
-
-          const client = createClient({
-            cluster: 'mainnet-beta',
-            walletConnectors: autoDiscover(),
-          });
-
-          <FormoAnalyticsProvider
-            writeKey="<YOUR_WRITE_KEY>"
-            options={{ evm: false, solana: { store: client.store } }}
-          >
-            <YourApp />
-          </FormoAnalyticsProvider>
-        ```
-      </Accordion>
-      <Accordion title="wallet-adapter, Privy, Dynamic, Reown, or custom">
-        There is no store to observe, so **nothing is autocaptured**. Emit wallet events yourself with [`connect`](/data/events/connect) and [`disconnect`](/data/events/disconnect).
-
-        ```tsx
-          import { useEffect, useRef } from 'react';
-          import { useWallet } from '@solana/wallet-adapter-react';
-          import { useFormo, SOLANA_CHAIN_IDS } from '@formo/analytics';
-
-          const CHAIN_ID = SOLANA_CHAIN_IDS['mainnet-beta'];
-
-          function WalletTracking() {
-            const formo = useFormo();
-            const { publicKey, wallet, connected } = useWallet();
-            const lastAddress = useRef<string | null>(null);
-
-            useEffect(() => {
-              if (!formo) return;
-              const address = publicKey?.toBase58() ?? null;
-
-              if (connected && address && address !== lastAddress.current) {
-                formo.connect(
-                  { chainId: CHAIN_ID, address },
-                  { providerName: wallet?.adapter.name },
-                );
-                lastAddress.current = address;
-              }
-
-              if (!connected && lastAddress.current) {
-                formo.disconnect({ chainId: CHAIN_ID, address: lastAddress.current });
-                lastAddress.current = null;
-              }
-            }, [formo, connected, publicKey, wallet]);
-
-            return null;
-          }
-        ```
-
-        Render `<WalletTracking />` once inside your wallet provider. Driving it from an effect (rather than the wallet modal's success handler) means restored sessions are counted too.
-      </Accordion>
-    </AccordionGroup>
-
-    <Warning>
-    Do not report wallet connections with `track()`. A custom event such as `track('Connect', { address })` is stored as a track event, not the built-in `connect` type, so the **Connect wallet** funnel step, first-time wallet connection charts, and wallet provider breakdowns will all be empty. Use `connect()` for wallet connections and `track()` for product events.
-    </Warning>
-
-    #### 3. Identify users
-
-    Call [`identify`](/data/events/identify) once a wallet address is known.
-
-    ```tsx
-    import { useFormo } from "@formo/analytics";
-    import { useWallet } from "@solana/wallet-adapter-react";
-
-    const HomePage = () => {
-      const { publicKey } = useWallet();
-      const analytics = useFormo();
-
-      useEffect(() => {
-        const address = publicKey?.toBase58();
-        if (address && analytics) {
-          analytics.identify({ address });
-        }
-      }, [publicKey, analytics]);
-    }
-    ```
-
-    #### 4. Track custom events
-
-    Transactions and signatures need explicit [`transaction`](/data/events/transaction) and [`signature`](/data/events/signature) calls on both paths. For app-specific actions, use [`track`](/sdks/web#track-events).
-
-    ```tsx
-      analytics.track('Vault Deposit Completed', { vault_name: 'USD*', volume: 100 });
-    ```
-
-  </Tab>
   <Tab icon="angular" title="Angular">
 
     <Note>
@@ -933,6 +821,114 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
         this.formo.track('Swap Completed', { volume: 100 });
       }
     }
+    ```
+
+  </Tab>
+  <Tab icon="circle-nodes" title="Solana">
+
+    <Note>
+    Full reference: [Solana integration](/sdks/web#solana-integration) on the Web SDK page.
+    </Note>
+
+    #### 1. Install the Formo SDK
+
+    ```bash
+      npm install @formo/analytics --save
+    ```
+
+    #### 2. Choose your integration path
+
+    How you set up depends on the wallet library your app uses.
+
+    <AccordionGroup>
+      <Accordion title="framework-kit (autocapture)">
+        Pass `client.store` and the SDK captures connects, disconnects, and cluster switches automatically.
+
+        ```tsx
+          import { createClient, autoDiscover } from '@solana/client';
+          import { FormoAnalyticsProvider } from '@formo/analytics';
+
+          const client = createClient({
+            cluster: 'mainnet-beta',
+            walletConnectors: autoDiscover(),
+          });
+
+          <FormoAnalyticsProvider
+            writeKey="<YOUR_WRITE_KEY>"
+            options={{ evm: false, solana: { store: client.store } }}
+          >
+            <YourApp />
+          </FormoAnalyticsProvider>
+        ```
+      </Accordion>
+      <Accordion title="wallet-adapter, Privy, Dynamic, Reown, or custom">
+        There is no store to observe, so **nothing is autocaptured**. Emit wallet events yourself with [`connect`](/data/events/connect) and [`disconnect`](/data/events/disconnect).
+
+        ```tsx
+          import { useEffect, useRef } from 'react';
+          import { useWallet } from '@solana/wallet-adapter-react';
+          import { useFormo, SOLANA_CHAIN_IDS } from '@formo/analytics';
+
+          const CHAIN_ID = SOLANA_CHAIN_IDS['mainnet-beta'];
+
+          function WalletTracking() {
+            const formo = useFormo();
+            const { publicKey, wallet, connected } = useWallet();
+            const lastAddress = useRef<string | null>(null);
+
+            useEffect(() => {
+              if (!formo) return;
+              const address = publicKey?.toBase58() ?? null;
+
+              if (connected && address && address !== lastAddress.current) {
+                formo.connect(
+                  { chainId: CHAIN_ID, address },
+                  { providerName: wallet?.adapter.name },
+                );
+                lastAddress.current = address;
+              }
+
+              if (!connected && lastAddress.current) {
+                formo.disconnect({ chainId: CHAIN_ID, address: lastAddress.current });
+                lastAddress.current = null;
+              }
+            }, [formo, connected, publicKey, wallet]);
+
+            return null;
+          }
+        ```
+
+        Render `<WalletTracking />` once inside your wallet provider. Driving it from an effect (rather than the wallet modal's success handler) means restored sessions are counted too.
+      </Accordion>
+    </AccordionGroup>
+
+    #### 3. Identify users
+
+    Call [`identify`](/data/events/identify) once a wallet address is known.
+
+    ```tsx
+    import { useFormo } from "@formo/analytics";
+    import { useWallet } from "@solana/wallet-adapter-react";
+
+    const HomePage = () => {
+      const { publicKey } = useWallet();
+      const analytics = useFormo();
+
+      useEffect(() => {
+        const address = publicKey?.toBase58();
+        if (address && analytics) {
+          analytics.identify({ address });
+        }
+      }, [publicKey, analytics]);
+    }
+    ```
+
+    #### 4. Track custom events
+
+    Transactions and signatures need explicit [`transaction`](/data/events/transaction) and [`signature`](/data/events/signature) calls on both paths. For app-specific actions, use [`track`](/sdks/web#track-events).
+
+    ```tsx
+      analytics.track('Vault Deposit Completed', { vault_name: 'USD*', volume: 100 });
     ```
 
   </Tab>

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -825,19 +825,6 @@ There are two ways to integrate Solana, depending on which wallet library your a
 - **[framework-kit](#solana-with-framework-kit)** (`@solana/client` + `@solana/react-hooks`): the SDK subscribes to framework-kit's zustand store and captures wallet events automatically.
 - **[Any other wallet library](#solana-without-framework-kit)** (`@solana/wallet-adapter`, Privy, Dynamic, Reown, or a custom connector): call `formo.connect()` and `formo.disconnect()` yourself.
 
-Both paths produce the same `connect` and `disconnect` event types, so the dashboard treats them identically.
-
-<Warning>
-Do not report wallet connections with `formo.track()`. A custom event such as `formo.track('Connect', { address })` is stored as a track event, not as the built-in `connect` type, so it will not reach anything that reads wallet connections:
-
-- the **Connect wallet** step in [funnels](/guides/funnels) and [flows](/guides/flows) returns zero
-- first-time and daily wallet connection charts stay empty
-- breakdowns by wallet provider are unavailable
-- sessions are not attributed to the wallet
-
-Use `formo.connect()` for wallet connections and reserve `formo.track()` for product events such as swaps, deposits, and mints.
-</Warning>
-
 #### Solana with framework-kit
 
 The SDK subscribes to framework-kit's zustand store as a read-only observer. It never wraps or intercepts wallet methods.
@@ -930,6 +917,17 @@ The following Solana wallet events are autocaptured via zustand store subscripti
 #### Solana without framework-kit
 
 If your app uses `@solana/wallet-adapter`, Privy, Dynamic, Reown, or a custom connector, there is no store for the SDK to observe, so nothing is autocaptured. Call `formo.connect()` and `formo.disconnect()` at the points where your wallet state changes.
+
+<Warning>
+Do not report wallet connections with `formo.track()`. A custom event such as `formo.track('Connect', { address })` is stored as a track event, not as the built-in `connect` type, so it will not reach anything that reads wallet connections:
+
+- the **Connect wallet** step in [funnels](/guides/funnels) and [flows](/guides/flows) returns zero
+- first-time and daily wallet connection charts stay empty
+- breakdowns by wallet provider are unavailable
+- sessions are not attributed to the wallet
+
+Use `formo.connect()` for wallet connections and reserve `formo.track()` for product events such as swaps, deposits, and mints.
+</Warning>
 
 Initialize the SDK without the `solana.store` option:
 

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -820,7 +820,27 @@ Use the same `QueryClient` instance for both Wagmi and Formo to avoid creating m
 
 ### Solana integration
 
-The Formo Web SDK supports Solana via [framework-kit](https://github.com/solana-foundation/framework-kit) (`@solana/client` + `@solana/react-hooks`). The SDK subscribes to framework-kit's zustand store as a read-only observer. It never wraps or intercepts wallet methods.
+There are two ways to integrate Solana, depending on which wallet library your app uses:
+
+- **[framework-kit](#solana-with-framework-kit)** (`@solana/client` + `@solana/react-hooks`): the SDK subscribes to framework-kit's zustand store and captures wallet events automatically.
+- **[Any other wallet library](#solana-without-framework-kit)** (`@solana/wallet-adapter`, Privy, Dynamic, Reown, or a custom connector): call `formo.connect()` and `formo.disconnect()` yourself.
+
+Both paths produce the same `connect` and `disconnect` event types, so the dashboard treats them identically.
+
+<Warning>
+Do not report wallet connections with `formo.track()`. A custom event such as `formo.track('Connect', { address })` is stored as a track event, not as the built-in `connect` type, so it will not reach anything that reads wallet connections:
+
+- the **Connect wallet** step in [funnels](/guides/funnels) and [flows](/guides/flows) returns zero
+- first-time and daily wallet connection charts stay empty
+- breakdowns by wallet provider are unavailable
+- sessions are not attributed to the wallet
+
+Use `formo.connect()` for wallet connections and reserve `formo.track()` for product events such as swaps, deposits, and mints.
+</Warning>
+
+#### Solana with framework-kit
+
+The SDK subscribes to framework-kit's zustand store as a read-only observer. It never wraps or intercepts wallet methods.
 
 See the full [Solana example app](https://github.com/getformo/examples/tree/main/with-solana) for a working implementation.
 
@@ -907,9 +927,85 @@ The following Solana wallet events are autocaptured via zustand store subscripti
 | Disconnect | Wallet disconnects |
 | Chain change | Cluster/network switches via `setCluster()` |
 
+#### Solana without framework-kit
+
+If your app uses `@solana/wallet-adapter`, Privy, Dynamic, Reown, or a custom connector, there is no store for the SDK to observe, so nothing is autocaptured. Call `formo.connect()` and `formo.disconnect()` at the points where your wallet state changes.
+
+Initialize the SDK without the `solana.store` option:
+
+```tsx
+<FormoAnalyticsProvider
+  writeKey="<YOUR_WRITE_KEY>"
+  options={{ evm: false }}
+>
+  <YourApp />
+</FormoAnalyticsProvider>
+```
+
+Then emit the events. This example uses `@solana/wallet-adapter-react`, but the same shape applies to any library that exposes a connected address:
+
+```tsx
+import { useEffect, useRef } from 'react';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { useFormo, SOLANA_CHAIN_IDS } from '@formo/analytics';
+
+const CHAIN_ID = SOLANA_CHAIN_IDS['mainnet-beta'];
+
+function WalletTracking() {
+  const formo = useFormo();
+  const { publicKey, wallet, connected } = useWallet();
+  const lastAddress = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!formo) return;
+    const address = publicKey?.toBase58() ?? null;
+
+    if (connected && address && address !== lastAddress.current) {
+      formo.connect(
+        { chainId: CHAIN_ID, address },
+        { providerName: wallet?.adapter.name },
+      );
+      lastAddress.current = address;
+    }
+
+    if (!connected && lastAddress.current) {
+      formo.disconnect({ chainId: CHAIN_ID, address: lastAddress.current });
+      lastAddress.current = null;
+    }
+  }, [formo, connected, publicKey, wallet]);
+
+  return null;
+}
+```
+
+Render `<WalletTracking />` once inside your wallet provider.
+
+<Note>
+Emit `connect` whenever the wallet becomes connected, including when your app restores a session on page load. If you only call `formo.connect()` from the wallet modal's success handler, returning users are never counted and your first-time connection numbers will be too low. Driving the call from an effect on wallet state (as above) covers both cases.
+</Note>
+
+**Solana chain IDs**
+
+Solana has no numeric chain ID, so Formo maps each cluster to a reserved ID above 900000 to avoid colliding with EVM chains. Use the exported constant rather than hardcoding the number.
+
+| Cluster | `SOLANA_CHAIN_IDS` value |
+|---------|--------------------------|
+| `mainnet-beta` | `900001` |
+| `testnet` | `900002` |
+| `devnet` | `900003` |
+| `localnet` | `900004` |
+
+`connect()` validates the address against the chain ID, so a base58 Solana address paired with an EVM chain ID is rejected. Rejected calls log a warning and emit nothing. Enable logging while integrating so you see them:
+
+```tsx
+options={{ logger: { enabled: true, levels: ['info', 'warn', 'error'] } }}
+```
+
+Connections are also skipped when tracking is suppressed for the visitor, for example by an opt-out or an excluded host, timezone, or path.
+
 **Manually tracking Solana transactions and signatures**
 
-Transaction and signature events for Solana wallets must be tracked explicitly because framework-kit's React hooks (`useSolTransfer`, `useSendTransaction`, `useTransactionPool`) manage transaction state locally and don't write to the store.
+Transaction and signature events for Solana wallets must be tracked explicitly on both integration paths. On framework-kit this is because its React hooks (`useSolTransfer`, `useSendTransaction`, `useTransactionPool`) manage transaction state locally and don't write to the store.
 
 ```tsx
 import { useFormo, TransactionStatus, SignatureStatus, SOLANA_CHAIN_IDS } from '@formo/analytics';

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -993,6 +993,8 @@ Solana has no numeric chain ID, so Formo maps each cluster to a reserved ID abov
 | `devnet` | `900003` |
 | `localnet` | `900004` |
 
+Mainnet has two spellings: `@solana/client` takes `cluster: 'mainnet'`, while `SOLANA_CHAIN_IDS` is keyed on `'mainnet-beta'`. Map between them when you derive one from the other.
+
 `connect()` validates the address against the chain ID, so a base58 Solana address paired with an EVM chain ID is rejected. Rejected calls log a warning and emit nothing. Enable logging while integrating so you see them:
 
 ```tsx

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -18,7 +18,7 @@ Use this pre-built prompt to get started faster: [Install Formo with AI](/instal
 
 There are several ways to install the Formo SDK:
 - [Wagmi](#wagmi) is recommended for EVM apps with wallet connection
-- [Solana](#solana-integration) for Solana apps using framework-kit
+- [Solana](#solana-integration) for Solana apps, with or without framework-kit
 - [HTML Snippet](#html-snippet) is recommended for static websites
 - [React & Next.js (without Wagmi)](#react--nextjs-without-wagmi)
 - [Angular](#angular) for Angular apps using the bare EIP-1193 provider
@@ -1025,23 +1025,6 @@ formo.signature({ status: SignatureStatus.CONFIRMED, chainId: SOLANA_CHAIN_IDS['
 For Solana-only apps, set `evm: false` to disable EVM provider detection (EIP-1193 / EIP-6963). This prevents unnecessary tracking of injected EVM wallets.
 </Note>
 
-## FAQ
-
-<AccordionGroup>
-  <Accordion title="What is the difference between the Wagmi integration and the standard React integration?">
-    The [Wagmi integration](#wagmi) automatically tracks wallet connects, disconnects, chain switches, transactions, and signatures by hooking into Wagmi's wallet adapter. The standard [React integration](#react--nextjs-without-wagmi) tracks wallet events by wrapping the EIP-1193 wallet provider to track signatures and transactions. Use the Wagmi integration if your app uses Wagmi and its hooks.
-  </Accordion>
-  <Accordion title="How do I track custom events like swaps, deposits, or mints?">
-    Use [formo.track()](/data/events/track) to send custom events with any properties you need. For example: `formo.track('Swap Completed', { pair: 'ETH/USDC', token_in: 'ETH', token_out: 'USDC', amount_in: 1.5 })`. Custom events appear in the [Activity](/features/product-analytics/activity) feed and can be queried in the [Explorer](/features/product-analytics/explore).
-  </Accordion>
-  <Accordion title="Does the Formo SDK support consent management for GDPR?">
-    Yes. The SDK provides built-in [consent management](#consent-management) with `optOutTracking()` and `optInTracking()` methods. Call `optOutTracking()` to stop all tracking for a user, and `optInTracking()` to re-enable it. Formo does not use third-party cookies, IP addresses, or device fingerprinting, so most jurisdictions do not require a cookie consent banner.
-  </Accordion>
-  <Accordion title="Can I use Formo with Privy or other embedded wallet providers?">
-    Yes. The SDK includes a dedicated [Privy integration](#identify-users) with `parsePrivyProperties()` to extract profile properties and linked wallet addresses. For other wallet providers, use the standard [React integration](#react--nextjs-without-wagmi). If your wallet provider uses Wagmi under the hood (many do, including Privy), you can also use the [Wagmi integration](#wagmi) for automatic wallet event tracking.
-  </Accordion>
-</AccordionGroup>
-
 ## Proxy
 
 To handle ad-blockers and privacy browsers, we recommend setting up a reverse proxy.
@@ -1179,3 +1162,28 @@ To verify the proxy is working:
 - Open the network tab in your browser's developer tools
 - Check that analytics requests are going through your domain instead of `events.formo.so`
 - Check that events show up in the Activity page on the Formo dashboard
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="What is the difference between the Wagmi integration and the standard React integration?">
+    The [Wagmi integration](#wagmi) automatically tracks wallet connects, disconnects, chain switches, transactions, and signatures by hooking into Wagmi's wallet adapter. The standard [React integration](#react--nextjs-without-wagmi) tracks wallet events by wrapping the EIP-1193 wallet provider to track signatures and transactions. Use the Wagmi integration if your app uses Wagmi and its hooks.
+  </Accordion>
+  <Accordion title="How do I track custom events like swaps, deposits, or mints?">
+    Use [formo.track()](/data/events/track) to send custom events with any properties you need. For example: `formo.track('Swap Completed', { pair: 'ETH/USDC', token_in: 'ETH', token_out: 'USDC', amount_in: 1.5 })`. Custom events appear in the [Activity](/features/product-analytics/activity) feed and can be queried in the [Explorer](/features/product-analytics/explore).
+  </Accordion>
+  <Accordion title="Does the Formo SDK support consent management for GDPR?">
+    Yes. The SDK provides built-in [consent management](#consent-management) with `optOutTracking()` and `optInTracking()` methods. Call `optOutTracking()` to stop all tracking for a user, and `optInTracking()` to re-enable it. Formo does not use third-party cookies, IP addresses, or device fingerprinting, so most jurisdictions do not require a cookie consent banner.
+  </Accordion>
+  <Accordion title="Can I use Formo with Privy or other embedded wallet providers?">
+    Yes. The SDK includes a dedicated [Privy integration](#identify-users) with `parsePrivyProperties()` to extract profile properties and linked wallet addresses. For other wallet providers, use the standard [React integration](#react--nextjs-without-wagmi). If your wallet provider uses Wagmi under the hood (many do, including Privy), you can also use the [Wagmi integration](#wagmi) for automatic wallet event tracking.
+  </Accordion>
+  <Accordion title="Why are my Solana wallet connections not showing up?">
+    Wallet events are autocaptured on Solana only when your app passes a [framework-kit](#solana-with-framework-kit) store to `options.solana.store`. With `@solana/wallet-adapter`, Privy, Dynamic, Reown, or a custom connector there is no wallet state for the SDK to observe, so nothing is captured until you emit it yourself. See [Solana without framework-kit](#solana-without-framework-kit).
+
+    Sending connections as a custom `track()` event instead will not work: they are stored as track events rather than the built-in `connect` type, so the **Connect wallet** funnel step and every wallet connection chart stay empty.
+  </Accordion>
+  <Accordion title="Do I need framework-kit to use Formo on Solana?">
+    No. framework-kit gives you autocapture for connects, disconnects and cluster switches, but any Solana app can integrate by calling [`formo.connect()`](/data/events/connect) and `formo.disconnect()` directly. Both paths produce the same `connect` and `disconnect` event types, so the dashboard treats them identically. Transactions and signatures need explicit `formo.transaction()` and `formo.signature()` calls on either path.
+  </Accordion>
+</AccordionGroup>

--- a/security/overview.mdx
+++ b/security/overview.mdx
@@ -145,6 +145,10 @@ For the CDN script tag method, enable [SRI](/security/sri) and [CSP](/security/c
 </Card>
 
 
+## Contact
+
+If you have any questions, [contact us](https://formo.so/support).
+
 ## FAQ
 
 <AccordionGroup>
@@ -161,7 +165,3 @@ For the CDN script tag method, enable [SRI](/security/sri) and [CSP](/security/c
     Yes. Formo supports [Single Sign-On (SSO)](/security/sso) for centralized authentication through your identity provider, [multi-factor authentication (MFA)](/security/mfa) via TOTP, and [role-based access control](/security/roles) with Owner, Admin, Editor, and Viewer roles.
   </Accordion>
 </AccordionGroup>
-
-## Contact
-
-If you have any questions, [contact us](https://formo.so/support).


### PR DESCRIPTION
## Why

A Solana app that does not use framework-kit had **no documented way to emit a native `connect` event**.

- The Solana section of `sdks/web.mdx` covered only the framework-kit store integration.
- Its manual-tracking subsection covered `transaction` and `signature`, but never `connect`/`disconnect`.
- `install.mdx` told readers in four separate places that wallet events are autocaptured and "you do not need to track them manually". That is false for Solana outside framework-kit.
- The one-click AI install prompt had no Solana option at all, so it generates integrations with zero wallet events for Solana apps.

A team on `@solana/wallet-adapter`, Privy, Dynamic or Reown following these pages reasonably concludes wallet connections are handled, finds they are not, and reaches for `formo.track('Connect')`. That lands as a track event rather than the `connect` type, so the **Connect wallet** funnel step, first-time wallet connection charts and wallet-provider breakdowns all read empty while the data looks present.

This is not hypothetical: it is the root cause of a live customer reporting an empty Connect wallet funnel step.

## What changed

**`sdks/web.mdx`**
- Splits the Solana section into two explicit paths: with framework-kit (autocapture) and without (manual).
- Adds a `@solana/wallet-adapter` example calling `connect()`/`disconnect()` from an effect on wallet state, so restored sessions are counted rather than only modal click-throughs.
- Documents the `SOLANA_CHAIN_IDS` cluster mapping (900001-900004) that existing code samples already used without ever explaining.
- Lists the conditions under which `connect()` silently returns, notably a base58 address paired with an EVM `chainId`.
- Corrects the transactions/signatures subsection, which implied manual tracking was a framework-kit quirk; it applies to both paths.

**`install.mdx`**
- New Solana tab with both integration paths.
- Qualifies the global autocapture claims.
- Points the React and Next.js tabs at the Solana tab.
- Adds a "Why are my Solana wallet connections not showing up?" FAQ.
- Teaches the AI install prompt an Option E plus a guardrail against using `track()` for wallet events.

**`data/events/connect.mdx`**
- Adds a Solana sample payload alongside the EVM one and widens `provider_name` beyond wagmi.

## Verification

`npx mintlify validate` passes. No em dashes (per `CLAUDE.md` writing style). All cross-page anchors resolve to real headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788079022&installation_model_id=21031&pr_number=126&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F126&signature=8ff65705e8c337a8d92c9867be4840a09528327af711bf810e5b6b75d4314ea1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->