### PR TITLE
docs(cli): per-field operator support, page_scope, retired filter params

### DIFF
--- a/cli/analytics.mdx
+++ b/cli/analytics.mdx
@@ -54,6 +54,12 @@ Requires `query:read` scope on your API key.
 
 A JSON array of `{ field, op, value }` filters, e.g. `[{"field":"location","op":"eq","value":"US"}]`. For multi-value matching, use `in` / `nin` with an array value (e.g. `["chrome","firefox"]`); pipe-delimited strings remain supported by the analytics query boundary.
 
+This one array carries every predicate. On the user-aggregate pipes (`lifecycle`, `frequency`) it also takes profile metrics, social identity fields, a lifecycle entry (`{"field":"lifecycle","op":"in","value":["New","Power user"]}`), and resource entries using the stable fields `chains.balance`, `apps.balance`, `tokens.balance` and `labels.value` with named qualifiers (`chain_id`, `app_id`, `token_address`, `scope`, `tag_id`).
+
+<Warning>
+The retired per-family params — `socials`, `chain_filters`, `app_filters`, `token_filters`, `label_filters`, `profile_filters`, `lifecycle_filter` — are rejected with a `400` if passed through `--params`. Forwarding them would silently drop the predicate and broaden the result set, so the API fails loud instead. Send a canonical entry in `--filters`.
+</Warning>
+
 ### `--params` (pipe-specific)
 
 Some pipes take additional, pipe-specific parameters. Pass them as a JSON object via `--params`:
@@ -68,6 +74,9 @@ Some pipes take additional, pipe-specific parameters. Pass them as a JSON object
 | `revenue_timeseries` | `address` (required) |
 | `revenue_by_metric`, `volume_by_metric`, `top_sources` | `metric_column`, `limit`, `offset` |
 | `top_chains`, `top_events`, `top_locations`, `top_pages`, `top_wallets` | `limit`, `offset` |
+| `kpis`, `top_*`, `revenue_*`, `volume_by_metric` | `page_scope` — `page` (default) or `session` |
+
+`page_scope` only affects requests that carry a `page` filter. The default scopes metrics to activity on that page; `session` restores the legacy behaviour where metrics include all activity in any session that viewed the page.
 
 ### Examples
 

--- a/cli/profiles.mdx
+++ b/cli/profiles.mdx
@@ -128,9 +128,23 @@ The response is a paginated envelope: `{ data, total, page, size, has_more }`.
 
 ### Filter Operators
 
-`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `notEmpty`, `isEmpty`
+`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `startsWith`, `endsWith`, `notEmpty`, `isEmpty`
 
 The long-form spellings (`equals`, `notEquals`, `greater`, `greaterOrEqual`, `less`, `lessOrEqual`, `notIn`, `includes`) are retired. The API rejects them with a `400` naming the token. Use only the canonical operators above.
+
+The vocabulary is shared, but each field implements a subset — an unsupported pairing is a `400`:
+
+| Field class | Supported operators |
+|-------------|---------------------|
+| `chains.balance`, `apps.balance`, `tokens.balance` | `eq`, `neq`, `gt`, `gte`, `lt`, `lte` — the value must be a JSON number, not a numeric string |
+| `labels.value` | comparison operators plus `contains` (case-insensitive) |
+| Numeric profile metrics (`users.net_worth_usd`, `users.volume`, `users.revenue`, `users.points`) | comparison operators |
+| Routable string attributes (`users.device`, `users.os`, `users.referrer`, `users.utm_*`, `users.click_id`, and the `first_*`/`last_*` attribution variants) | the full vocabulary; `contains`, `startsWith` and `endsWith` match case-sensitively |
+| Social fields (`users.twitter`, `users.email`, `users.farcaster`, …) | `contains` (case-insensitive) and `notEmpty`; `startsWith`, `endsWith` and `isEmpty` are rejected |
+| `users.paid_source` (and its `first_`/`last_` variants) | `eq`, `neq`, `in`, `nin`, `notEmpty`, `isEmpty` — it is a fixed ad-network enum |
+| `users.lifecycle` | `eq` (one stage) and `in` (a list of stages) |
+
+`notEmpty` and `isEmpty` are value-less existence checks; the `value` is ignored.
 
 ---
 


### PR DESCRIPTION
## Why

Follow-up to #124 and #125, which brought the CLI docs onto the canonical filter envelope. Two gaps remained.

`contains` was listed alongside the other operators with no per-field guidance, and `startsWith`/`endsWith` were absent from the list even though the API accepts them. Per `packages/shared/constants/filterCapability.ts` in `formono`, each field class implements a different subset and an unsupported pairing is a `400` — the docs gave no way to predict that.

## What changed

**`cli/profiles.mdx`** — add `startsWith`/`endsWith` to the operator list, plus the per-field support table:

- `.balance` fields: comparison operators only, JSON number values
- `labels.value`: comparison plus `contains` (case-insensitive, new in P-2387)
- routable string attributes: full vocabulary, case-sensitive substring matching
- social fields: `contains` + `notEmpty`; `startsWith`/`endsWith`/`isEmpty` rejected
- `users.paid_source`: fixed ad-network enum
- `users.lifecycle`: `eq` and `in` only

**`cli/analytics.mdx`** — document `page_scope` (P-2378, on `kpis`/`top_*`/`revenue_*`/`volume_by_metric`), spell out that the single `--filters` array now carries profile, social, lifecycle and resource predicates on the user-aggregate pipes, and warn that the retired per-family params are rejected with a `400` rather than ignored.

Pairs with getformo/cli#34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788316441&installation_model_id=21031&pr_number=129&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F129&signature=fb2ee93ee8d4e0bb0ff972be12c90205c14d3ff21ebfb3260dc520a8262de0e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->