### PR TITLE
Document paid_source grouping on the revenue endpoints

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6602,6 +6602,7 @@
                 "pathname",
                 "origin",
                 "channel",
+                "paid_source",
                 "referrer",
                 "referrer_url",
                 "ref",
@@ -6621,7 +6622,7 @@
                 "event"
               ]
             },
-            "description": "Column to group revenue by. Use `channel` for the 12-channel acquisition classifier (see docs/channels.md). Unknown values return zero rows."
+            "description": "Column to group revenue by. Use `channel` for the 12-channel acquisition classifier (see docs/channels.md). Use `paid_source` for the acquiring ad network (per-event sticky attribution; paid rows only — see docs/ads.md). Unknown values return zero rows."
           },
           {
             "$ref": "#/components/parameters/AnalyticsLimit"
@@ -6728,6 +6729,7 @@
                 "pathname",
                 "origin",
                 "channel",
+                "paid_source",
                 "referrer",
                 "referrer_url",
                 "ref",
@@ -6747,7 +6749,7 @@
                 "event"
               ]
             },
-            "description": "Column to group volume by. Use `channel` for the 12-channel acquisition classifier (see docs/channels.md). Unknown values return zero rows."
+            "description": "Column to group volume by. Use `channel` for the 12-channel acquisition classifier (see docs/channels.md). Use `paid_source` for the acquiring ad network (per-event sticky attribution; paid rows only — see docs/ads.md). Unknown values return zero rows."
           },
           {
             "$ref": "#/components/parameters/AnalyticsLimit"
@@ -6849,7 +6851,8 @@
             "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Breakdown dimension. Valid options: referrer, location, device, browser, os, utm_source, utm_medium, utm_campaign, utm_content, utm_term, ref, builder_codes, channel_type, paid_source. Unknown values are ignored (ungrouped totals). `paid_source` is the acquiring ad network (per-event sticky attribution; empty bucket is 'None' — see docs/ads.md)."
           },
           {
             "name": "limit",

--- a/api/query/revenue-by-metric.mdx
+++ b/api/query/revenue-by-metric.mdx
@@ -4,4 +4,4 @@ description: "Revenue grouped by a chosen column (e.g. pathname, referrer)."
 openapi: "GET /v0/revenue_by_metric"
 ---
 
-Returns total revenue broken down by `metric_column`. The required `metric_column` query parameter selects the dimension to group by - for example `pathname`, `referrer`, `utm_source`, or `location`.
+Returns total revenue broken down by `metric_column`. The required `metric_column` query parameter selects the dimension to group by - for example `pathname`, `referrer`, `utm_source`, or `location`. Use `paid_source` to group by acquiring ad network (per-event sticky attribution; rows with no paid touch are excluded).

--- a/api/query/volume-by-metric.mdx
+++ b/api/query/volume-by-metric.mdx
@@ -4,4 +4,4 @@ description: "Transaction volume grouped by a chosen column (e.g. pathname, refe
 openapi: "GET /v0/volume_by_metric"
 ---
 
-Returns total transaction volume broken down by `metric_column`. The required `metric_column` query parameter selects the dimension - for example `pathname`, `referrer`, `utm_source`, or `location`.
+Returns total transaction volume broken down by `metric_column`. The required `metric_column` query parameter selects the dimension - for example `pathname`, `referrer`, `utm_source`, or `location`. Use `paid_source` to group by acquiring ad network (per-event sticky attribution; rows with no paid touch are excluded).


### PR DESCRIPTION
Companion to getformo/formono#2152 (Revenue/Volume by ad network).

- `api/openapi.json`: synced with the backend spec — `paid_source` in both `metric_column` enums (`revenue_by_metric`, `volume_by_metric`), `revenue_overview.group_by` documented.
- Endpoint MDX prose mentions the ad-network grouping (per-event sticky attribution; paid rows only).

**Merge after** the Tinybird deploy from formono#2152 lands — the API rejects these values until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788397777&installation_model_id=21031&pr_number=130&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F130&signature=faaf8e3d8aef5d0741fc65848e49fc67f3d4bd7a862fbe8ed54111994f21799d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->