### PR TITLE
docs(install): add steps for finding the SDK write key

### DIFF
--- a/install.mdx
+++ b/install.mdx
@@ -310,10 +310,6 @@ Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find 
 - On the **General** tab, scroll to the **Credentials** section.
 - Copy the value of the **SDK Write Key** field.
 
-<Tip>
-The same key is shown above the install instructions during project setup, and in **Settings** → **General** → **How to install Formo**.
-</Tip>
-
 <Tabs>
   <Tab icon="star" title="Wagmi">
     #### 1. Install the Formo SDK

--- a/install.mdx
+++ b/install.mdx
@@ -303,7 +303,17 @@ For best results, install Formo on both your website (example.com) and your app 
 - For apps (app.example.com), use the Wagmi integration.
 - For static websites (example.com), use the HTML snippet.
 
-Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find it in your Formo project settings after creating a project.
+Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find it in your Formo project settings after creating a project:
+
+- Go to [app.formo.so](https://app.formo.so) and sign in.
+- Open the project switcher in the top bar and select the project you are installing.
+- Open the project switcher again and click **Settings**.
+- On the **General** tab, scroll to the **Credentials** section.
+- Copy the value of the **SDK Write Key** field.
+
+<Tip>
+The same key is shown above the install instructions during project setup, and in **Settings** → **General** → **How to install Formo**.
+</Tip>
 
 <Tabs>
   <Tab icon="star" title="Wagmi">

--- a/install.mdx
+++ b/install.mdx
@@ -306,8 +306,7 @@ For best results, install Formo on both your website (example.com) and your app 
 Use the same `<SDK_WRITE_KEY>` for both your website and your app. You can find it in your Formo project settings after creating a project:
 
 - Go to [app.formo.so](https://app.formo.so) and sign in.
-- Open the project switcher in the top bar and select the project you are installing.
-- Open the project switcher again and click **Settings**.
+- Open the project dropdown to select a project and click **Settings**.
 - On the **General** tab, scroll to the **Credentials** section.
 - Copy the value of the **SDK Write Key** field.
 


### PR DESCRIPTION
Users reported not knowing where the SDK write key lives in the app, so spell out the navigation path instead of only pointing at project settings.


Claude-Session: https://claude.ai/code/session_01SyPBpRAvhS7J6EbnxniU2x

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788401435&installation_model_id=21031&pr_number=131&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F131&signature=58607802a584a52202aa3f5db83910f57d9d0f8d9ab819a1d6580faa84ed8b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->