### PR TITLE
Document profile timestamp lookups

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4525,6 +4525,15 @@
               "type": "string"
             },
             "description": "Comma-separated: apps, chains, tokens, labels"
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Optional point in time for wallet-enrichment data. Returns the stored base snapshot closest to this instant instead of the latest snapshot; an exact-distance tie chooses the later snapshot. Expanded chains, apps, and tokens come from the profiling batch associated with that selected snapshot. Project engagement fields, project-defined identity overrides, and labels remain current. Must be ISO-8601 with a timezone."
           }
         ],
         "responses": {
@@ -4827,6 +4836,15 @@
               "type": "string"
             },
             "description": "Comma-separated: apps, chains, tokens, labels"
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Optional point in time for wallet-enrichment data. Requires the address query parameter; unbounded historical collection scans are rejected. Returns the wallet's stored base snapshot closest to this instant instead of its latest snapshot; an exact-distance tie chooses the later snapshot. Expanded chains, apps, and tokens come from the selected snapshot's profiling batch. Project engagement fields, project-defined identity overrides, and labels remain current. Must be ISO-8601 with a timezone."
           },
           {
             "name": "order_by",

--- a/cli/profiles.mdx
+++ b/cli/profiles.mdx
@@ -36,6 +36,7 @@ Requires `profiles:read` scope on your API key.
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `--expand` | `string` | ❌ | Comma-separated fields to expand: `apps`, `chains`, `tokens`, `labels` |
+| `--timestamp` | `string` | ❌ | ISO-8601 timestamp; return the closest stored wallet-enrichment snapshot |
 
 The lifecycle threshold options listed above are also supported.
 
@@ -45,6 +46,7 @@ The lifecycle threshold options listed above are also supported.
 formo profiles get 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
 formo profiles get vitalik.eth --expand labels,chains
 formo profiles get vitalik.eth --expand apps,chains,tokens,labels --churn-window-days 30
+formo profiles get vitalik.eth --timestamp 2025-06-21T10:03:00Z
 ```
 
 ---
@@ -63,6 +65,7 @@ Requires `profiles:read` scope on your API key.
 |--------|------|----------|-------------|
 | `--address` | `string` | ❌ | Filter by wallet address |
 | `--search` | `string` | ❌ | Free-text search across address and identity fields |
+| `--timestamp` | `string` | ❌ | ISO-8601 timestamp; requires `--address` and returns the closest stored wallet-enrichment snapshot |
 | `--page` | `number` | ❌ | Page number, 1-indexed |
 | `--size` | `number` | ❌ | Page size |
 | `--order-by` | `enum` | ❌ | Field to sort by |
@@ -86,6 +89,11 @@ formo profiles search --size 10
 # Search text fields
 formo profiles search --search vitalik --size 5
 
+# Return the closest stored snapshot for one wallet
+formo profiles search \
+  --address 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
+  --timestamp 2025-06-21T10:03:00Z
+
 # Top 5 profiles by net worth
 formo profiles search --order-by net_worth_usd --order-dir desc --size 5
 
@@ -107,6 +115,8 @@ formo profiles search \
 ```
 
 The response is a paginated envelope: `{ data, total, page, size, has_more }`.
+
+When `--timestamp` is present, wallet-enrichment fields come from the stored base snapshot closest to that instant. If two snapshots are equally close, the later snapshot is returned. Expanded chains, apps, and tokens come from the selected profiling batch. Project engagement fields, project-defined identity overrides, and labels remain current. Omitting `--timestamp` returns the latest profile.
 
 ### Filters
 


### PR DESCRIPTION
## Summary

- document the optional `timestamp` query parameter for single-profile and exact-address profile searches
- explain closest-snapshot selection, later-snapshot tie-breaking, and expansion behavior
- add CLI examples for historical wallet-enrichment lookups

## Why

The profiles API now supports point-in-time wallet-enrichment reads. The public OpenAPI reference and CLI documentation need to describe the parameter and clarify that project engagement fields, identity overrides, and labels remain current.

## Verification

- `npx mintlify validate`
- OpenAPI JSON parse check
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788411130&installation_model_id=21031&pr_number=132&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F132&signature=ff49e119dc643df8d9c8fb395eccec45c1c3185f81bdb2f740ba16b1b75dbdaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getformo/docs.formo.so/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

