### PR TITLE
docs(web): document new identify flow for privy

### DIFF
--- a/install.mdx
+++ b/install.mdx
@@ -208,13 +208,21 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
   **Using Privy?** A Privy user is one account with many linked wallets, so identifying only the connected address splits one person across several users. Pass the `usePrivy()` user instead and every linked wallet is identified under that user's DID, clustering them into one:
 
   // React / Next.js, Privy
-  const { user } = usePrivy();       // null when the session isn't a Privy one
-  const { address } = useAccount();  // plain wallet connect
+  const { user } = usePrivy();                        // null on non-Privy sessions
+  const { wallets, ready: walletsReady } = useWallets();
+  const { address } = useAccount();                   // plain wallet connect
+  const activeAddress = address ?? wallets[0]?.address;
+
   useEffect(() => {
     if (!analytics) return;
-    if (user) { analytics.identify(user); }
+    // Wait for Privy to finish discovering wallets: identify runs before the
+    // wagmi connect event on first load, so without this the active address is
+    // unresolved and attribution falls back to the embedded wallet.
+    if (!walletsReady) return;
+
+    if (user) { analytics.identify(user, { activeAddress }); }
     else if (address) { analytics.identify({ address }); }
-  }, [user, address, analytics]);
+  }, [user, address, activeAddress, walletsReady, analytics]);
 
   Key the effect on `user` so it re-runs on login and on every account link/unlink. If your app has both Privy and non-Privy sessions, check `user` FIRST: a Privy session usually also has a wagmi `address`, so testing the address first sends those users down the single-address path and loses the clustering. See [Privy integration](/sdks/web#privy-integration).
 

--- a/install.mdx
+++ b/install.mdx
@@ -9,7 +9,7 @@ Developers integrate Formo using SDKs, APIs, SQL access, webhooks, and data expo
 ## Install with AI
 
 <Tip>
-Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com/link/prompt?text=Install%20Formo%20Analytics%20using%20the%20instructions%20at%20https%3A%2F%2Fdocs.formo.so%2Finstall%20and%20https%3A%2F%2Fdocs.formo.so%2Fsdks%2Fweb.%20Detect%20the%20framework%20%28Wagmi%2C%20React%2C%20Next.js%2C%20Solana%29%20and%20follow%20the%20matching%20setup.%20Use%20%40formo%2Fanalytics%20as%20the%20only%20package.%20Wrap%20the%20app%20with%20FormoAnalyticsProvider.%20For%20Wagmi%2C%20place%20it%20inside%20WagmiProvider%20and%20QueryClientProvider%20and%20pass%20both%20config%20and%20queryClient%20via%20options.wagmi.%20For%20Next.js%20App%20Router%2C%20create%20a%20%27use%20client%27%20wrapper%20component.%20For%20Solana%2C%20wallet%20events%20are%20only%20autocaptured%20when%20a%20framework-kit%20store%20is%20passed%20via%20options.solana.store%3B%20with%20%40solana%2Fwallet-adapter%2C%20Privy%2C%20Dynamic%2C%20or%20Reown%20nothing%20is%20autocaptured%2C%20so%20call%20formo.connect%28%29%20and%20formo.disconnect%28%29%20from%20an%20effect%20on%20wallet%20state%2C%20and%20never%20report%20wallet%20connections%20with%20track%28%29.%20After%20setup%2C%20add%20identify%28%29%20after%20wallet%20connection%20and%20track%28%29%20for%20custom%20events.%20Analyze%20the%20codebase%20to%20suggest%20relevant%20custom%20events%20to%20track.)
+Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com/link/prompt?text=Install%20Formo%20Analytics%20using%20the%20instructions%20at%20https%3A%2F%2Fdocs.formo.so%2Finstall%20and%20https%3A%2F%2Fdocs.formo.so%2Fsdks%2Fweb.%20Detect%20the%20framework%20%28Wagmi%2C%20React%2C%20Next.js%2C%20Solana%29%20and%20follow%20the%20matching%20setup.%20Use%20%40formo%2Fanalytics%20as%20the%20only%20package.%20Wrap%20the%20app%20with%20FormoAnalyticsProvider.%20For%20Wagmi%2C%20place%20it%20inside%20WagmiProvider%20and%20QueryClientProvider%20and%20pass%20both%20config%20and%20queryClient%20via%20options.wagmi.%20For%20Next.js%20App%20Router%2C%20create%20a%20%27use%20client%27%20wrapper%20component.%20For%20Solana%2C%20wallet%20events%20are%20only%20autocaptured%20when%20a%20framework-kit%20store%20is%20passed%20via%20options.solana.store%3B%20with%20%40solana%2Fwallet-adapter%2C%20Privy%2C%20Dynamic%2C%20or%20Reown%20nothing%20is%20autocaptured%2C%20so%20call%20formo.connect%28%29%20and%20formo.disconnect%28%29%20from%20an%20effect%20on%20wallet%20state%2C%20and%20never%20report%20wallet%20connections%20with%20track%28%29.%20After%20setup%2C%20add%20identify%28%29%20after%20wallet%20connection%20and%20track%28%29%20for%20custom%20events.%20For%20Privy%2C%20pass%20the%20usePrivy%28%29%20user%20to%20identify%28user%29%20instead%20of%20an%20address%20so%20all%20of%20the%20user%27s%20linked%20wallets%20cluster%20under%20one%20DID.%20Analyze%20the%20codebase%20to%20suggest%20relevant%20custom%20events%20to%20track.)
 </Tip>
 
 <Accordion title="Copy prompt">
@@ -202,6 +202,16 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
       if (address && analytics) { analytics.identify({ address }); }
     }, [address, analytics]);
   };
+
+  **Using Privy?** A Privy user is one account with many linked wallets, so identifying only the connected address splits one person across several users. Pass the `usePrivy()` user instead and every linked wallet is identified under that user's DID, clustering them into one:
+
+  // React / Next.js — Privy
+  const { user } = usePrivy();
+  useEffect(() => {
+    if (user && analytics) { analytics.identify(user); }
+  }, [user, analytics]);
+
+  Key the effect on `user` so it re-runs on login and on every account link/unlink. See [Privy integration](/sdks/web#privy-integration).
 
   ### Track Custom Events
 

--- a/install.mdx
+++ b/install.mdx
@@ -36,7 +36,7 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
 
   If the project is a Solana app, **always** use Option E. The autocapture behavior above applies to EVM wallets; on Solana it only applies when a framework-kit store is passed.
 
-  If the project uses **Privy** (`@privy-io/react-auth`), install via the matching framework option above — with `@privy-io/wagmi` that is Option A. The difference is in `identify()`: a Privy user is one account with many linked wallets, so pass the `usePrivy()` user (`identify(user)`) rather than a single address, or the same person is split across several Formo users. See step 3.
+  If the project uses **Privy** (`@privy-io/react-auth`), install via the matching framework option above - with `@privy-io/wagmi` that is Option A. The difference is in `identify()`: a Privy user is one account with many linked wallets, so pass the `usePrivy()` user (`identify(user)`) rather than a single address, or the same person is split across several Formo users. See step 3.
 
   If you're able to use a web tool to access a URL, visit https://docs.formo.so/install to get the latest, up-to-date instructions.
 
@@ -207,13 +207,16 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
 
   **Using Privy?** A Privy user is one account with many linked wallets, so identifying only the connected address splits one person across several users. Pass the `usePrivy()` user instead and every linked wallet is identified under that user's DID, clustering them into one:
 
-  // React / Next.js — Privy
-  const { user } = usePrivy();
+  // React / Next.js, Privy
+  const { user } = usePrivy();       // null when the session isn't a Privy one
+  const { address } = useAccount();  // plain wallet connect
   useEffect(() => {
-    if (user && analytics) { analytics.identify(user); }
-  }, [user, analytics]);
+    if (!analytics) return;
+    if (user) { analytics.identify(user); }
+    else if (address) { analytics.identify({ address }); }
+  }, [user, address, analytics]);
 
-  Key the effect on `user` so it re-runs on login and on every account link/unlink. See [Privy integration](/sdks/web#privy-integration).
+  Key the effect on `user` so it re-runs on login and on every account link/unlink. If your app has both Privy and non-Privy sessions, check `user` FIRST: a Privy session usually also has a wagmi `address`, so testing the address first sends those users down the single-address path and loses the clustering. See [Privy integration](/sdks/web#privy-integration).
 
   ### Track Custom Events
 

--- a/install.mdx
+++ b/install.mdx
@@ -36,6 +36,8 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
 
   If the project is a Solana app, **always** use Option E. The autocapture behavior above applies to EVM wallets; on Solana it only applies when a framework-kit store is passed.
 
+  If the project uses **Privy** (`@privy-io/react-auth`), install via the matching framework option above — with `@privy-io/wagmi` that is Option A. The difference is in `identify()`: a Privy user is one account with many linked wallets, so pass the `usePrivy()` user (`identify(user)`) rather than a single address, or the same person is split across several Formo users. See step 3.
+
   If you're able to use a web tool to access a URL, visit https://docs.formo.so/install to get the latest, up-to-date instructions.
 
   Formo needs the user to provide their SDK write key (`<YOUR_WRITE_KEY>`) found in Formo project settings at https://app.formo.so.

--- a/install.mdx
+++ b/install.mdx
@@ -208,21 +208,13 @@ Use this pre-built prompt to install faster: [Open in Cursor](https://cursor.com
   **Using Privy?** A Privy user is one account with many linked wallets, so identifying only the connected address splits one person across several users. Pass the `usePrivy()` user instead and every linked wallet is identified under that user's DID, clustering them into one:
 
   // React / Next.js, Privy
-  const { user } = usePrivy();                        // null on non-Privy sessions
-  const { wallets, ready: walletsReady } = useWallets();
-  const { address } = useAccount();                   // plain wallet connect
-  const activeAddress = address ?? wallets[0]?.address;
-
+  const { user } = usePrivy();       // null when the session isn't a Privy one
+  const { address } = useAccount();  // plain wallet connect
   useEffect(() => {
     if (!analytics) return;
-    // Wait for Privy to finish discovering wallets: identify runs before the
-    // wagmi connect event on first load, so without this the active address is
-    // unresolved and attribution falls back to the embedded wallet.
-    if (!walletsReady) return;
-
-    if (user) { analytics.identify(user, { activeAddress }); }
+    if (user) { analytics.identify(user); }
     else if (address) { analytics.identify({ address }); }
-  }, [user, address, activeAddress, walletsReady, analytics]);
+  }, [user, address, analytics]);
 
   Key the effect on `user` so it re-runs on login and on every account link/unlink. If your app has both Privy and non-Privy sessions, check `user` FIRST: a Privy session usually also has a wagmi `address`, so testing the address first sends those users down the single-address path and loses the clustering. See [Privy integration](/sdks/web#privy-integration).
 

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -253,7 +253,7 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
     ```
   </Tab>
   <Tab title="Privy">
-    A Privy user is one account (a DID) with many linked wallets. Pass the `usePrivy()` user with `{ privy: true }` and the SDK identifies **every** linked wallet under that user's DID, so they cluster into a single user instead of one per address:
+    A Privy user is one account (a DID) with many linked wallets. Pass the `usePrivy()` user straight to `identify()` and the SDK identifies **every** linked wallet under that user's DID, so they cluster into a single user instead of one per address:
 
     ```tsx
     import { useFormo } from '@formo/analytics';
@@ -272,7 +272,7 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
       useEffect(() => {
         if (!user || !formo) return;
 
-        formo.identify(user, { privy: true, activeAddress });
+        formo.identify(user, { activeAddress });
       }, [user, formo, activeAddress]);
     }
     ```
@@ -1032,10 +1032,10 @@ For Solana-only apps, set `evm: false` to disable EVM provider detection (EIP-11
 
 A Privy user is **one account (a DID) with many linked wallets** — an embedded wallet plus any external wallets they connect over time. Because Formo is address-keyed, one person with 8 wallets would otherwise appear as 8 users.
 
-`identify(user, { privy: true })` resolves this in a single call: it expands `user.linkedAccounts` and emits one identify per linked wallet, each tagged with the same Privy DID, so they cluster into one user.
+`identify(user)` resolves this in a single call: it expands `user.linkedAccounts` and emits one identify per linked wallet, each tagged with the same Privy DID, so they cluster into one user.
 
 ```tsx
-formo.identify(user, { privy: true, activeAddress });
+formo.identify(user, { activeAddress });
 ```
 
 **What each wallet sends.** The shared profile parsed from `user.linkedAccounts` — `privyDid`, `privyCreatedAt`, `email`, `phone`, and socials (X, Discord, GitHub, Farcaster, Google, …) — plus that wallet's own `wallet_client`, `chain_type`, and `is_embedded`.

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -253,34 +253,35 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
     ```
   </Tab>
   <Tab title="Privy">
-    The SDK includes `parsePrivyProperties()` which extracts profile properties (email, social accounts) and all linked wallet addresses from the Privy user object.
-
-    Call `identify()` in a `useEffect` that triggers when the Privy user becomes available:
+    A Privy user is one account (a DID) with many linked wallets. Pass the `usePrivy()` user with `{ privy: true }` and the SDK identifies **every** linked wallet under that user's DID, so they cluster into a single user instead of one per address:
 
     ```tsx
-    import { useFormo, parsePrivyProperties } from '@formo/analytics';
-    import { usePrivy } from '@privy-io/react-auth';
+    import { useFormo } from '@formo/analytics';
+    import { usePrivy, useWallets } from '@privy-io/react-auth';
     import { useEffect } from 'react';
 
     function App() {
       const { user } = usePrivy();
+      const { wallets } = useWallets();
       const formo = useFormo();
+
+      // Depend on the address string, not the `wallets` array — useWallets()
+      // returns a new reference on many renders.
+      const activeAddress = wallets[0]?.address;
 
       useEffect(() => {
         if (!user || !formo) return;
 
-        const { properties, wallets } = parsePrivyProperties(user);
-
-        for (const wallet of wallets) {
-          formo.identify({ address: wallet.address, userId: user.id }, properties);
-        }
-      }, [user, formo]);
+        formo.identify(user, { privy: true, activeAddress });
+      }, [user, formo, activeAddress]);
     }
     ```
 
-    `parsePrivyProperties()` returns:
-    - `properties` - a flat object with `email`, `discord`, `twitter`, `farcaster`, `github`, `telegram`, `google`, `apple`, and other social identifiers from the Privy user's linked accounts
-    - `wallets` - all wallets linked to the Privy user, so each wallet is identified with the same profile properties
+    `user` is reactive, so this re-runs on login and on every link/unlink, keeping the identity graph current.
+
+    Only the active wallet takes over event attribution — `activeAddress` if you pass it, else the wallet Formo already tracks, else Privy's `user.wallet`. Every other linked wallet is recorded purely for clustering and never repoints attribution.
+
+    See the [Privy integration guide](https://github.com/getformo/sdk/blob/main/docs/PRIVY_INTEGRATION.md) for attribution rules, what each wallet sends, and when identity re-emits.
   </Tab>
   <Tab title="HTML Snippet">
     ```html
@@ -1026,6 +1027,34 @@ formo.signature({ status: SignatureStatus.CONFIRMED, chainId: SOLANA_CHAIN_IDS['
 <Note>
 For Solana-only apps, set `evm: false` to disable EVM provider detection (EIP-1193 / EIP-6963). This prevents unnecessary tracking of injected EVM wallets.
 </Note>
+
+### Privy integration
+
+A Privy user is **one account (a DID) with many linked wallets** — an embedded wallet plus any external wallets they connect over time. Because Formo is address-keyed, one person with 8 wallets would otherwise appear as 8 users.
+
+`identify(user, { privy: true })` resolves this in a single call: it expands `user.linkedAccounts` and emits one identify per linked wallet, each tagged with the same Privy DID, so they cluster into one user.
+
+```tsx
+formo.identify(user, { privy: true, activeAddress });
+```
+
+**What each wallet sends.** The shared profile parsed from `user.linkedAccounts` — `privyDid`, `privyCreatedAt`, `email`, `phone`, and socials (X, Discord, GitHub, Farcaster, Google, …) — plus that wallet's own `wallet_client`, `chain_type`, and `is_embedded`.
+
+Linked wallets include `wallet` and `smart_wallet` accounts, plus a `cross_app` account's embedded and smart wallets (e.g. Abstract Global Wallet). Addresses are deduplicated.
+
+**Attribution.** Only one wallet owns the current address that later `track()` and `page()` events are attributed to. It's chosen in order: `activeAddress` if you pass it, else the wallet Formo already tracks from a prior connect, else Privy's `user.wallet`. The first two are matched strictly — a connected wallet that isn't linked in Privy is left alone rather than overwritten.
+
+**When identity re-emits.** Identify events are deduplicated per session on the wallet, the user id, and the profile, so:
+
+- re-running with the same user and profile is deduplicated — no spam on re-render;
+- a wallet identified anonymously re-emits once the Privy DID is attached at login;
+- **linking or unlinking a profile account re-emits every linked wallet** with the updated profile, since those properties are shared across the cluster.
+
+<Note>
+Pass stable identity metadata in `properties`. A value that changes on every call (a timestamp, a random id) makes every identify a new event.
+</Note>
+
+For the framework-agnostic form, use `identifyPrivyUser(formo, user, options)` — the same behavior without the flag, available from the React-free `./core` entry.
 
 ## Proxy
 

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -262,7 +262,7 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
 
     function App() {
       const { user } = usePrivy();
-      const { wallets } = useWallets();
+      const { wallets, ready: walletsReady } = useWallets();
       const { address } = useAccount();  // plain wallet sessions
       const formo = useFormo();
 
@@ -272,6 +272,10 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
 
       useEffect(() => {
         if (!formo) return;
+        // Wait for Privy to finish discovering wallets: `user` can be ready
+        // first, and identifying in that window resolves no active address, so
+        // attribution falls back to user.wallet (usually the embedded wallet).
+        if (!walletsReady) return;
 
         // Check `user` first: a Privy session usually also has a wagmi
         // address, so testing the address first would lose the clustering.
@@ -280,15 +284,17 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
         } else if (address) {
           formo.identify({ address });
         }
-      }, [user, address, formo, activeAddress]);
+      }, [user, address, formo, activeAddress, walletsReady]);
     }
     ```
 
-    `user` is reactive, so this re-runs on login and on every link/unlink, keeping the identity graph current.
+    `user` is reactive, so this re-runs on login and on every link/unlink.
+
+    Wallet links are additive server-side: unlinking a wallet in Privy re-runs the effect for the remaining wallets, but the SDK emits no removal event, so an address that was already clustered stays clustered.
 
     Only the active wallet takes over event attribution - `activeAddress` if you pass it, else the wallet Formo already tracks, else Privy's `user.wallet`. Every other linked wallet is recorded purely for clustering and never repoints attribution.
 
-    See the [Privy integration guide](https://github.com/getformo/sdk/blob/main/docs/PRIVY_INTEGRATION.md) for attribution rules, what each wallet sends, and when identity re-emits.
+    See [Privy integration](#privy-integration) below for attribution rules, what each wallet sends, and when identity re-emits.
   </Tab>
   <Tab title="HTML Snippet">
     ```html
@@ -1228,7 +1234,7 @@ To verify the proxy is working:
     Yes. The SDK provides built-in [consent management](#consent-management) with `optOutTracking()` and `optInTracking()` methods. Call `optOutTracking()` to stop all tracking for a user, and `optInTracking()` to re-enable it. Formo does not use third-party cookies, IP addresses, or device fingerprinting, so most jurisdictions do not require a cookie consent banner.
   </Accordion>
   <Accordion title="Can I use Formo with Privy or other embedded wallet providers?">
-    Yes. The SDK includes a dedicated [Privy integration](#identify-users) with `parsePrivyProperties()` to extract profile properties and linked wallet addresses. For other wallet providers, use the standard [React integration](#react--nextjs-without-wagmi). If your wallet provider uses Wagmi under the hood (many do, including Privy), you can also use the [Wagmi integration](#wagmi) for automatic wallet event tracking.
+    Yes. The SDK includes a dedicated [Privy integration](#privy-integration): pass the `usePrivy()` user to `identify(user)` and every wallet linked to that Privy account is identified under the user's DID, so a multi-wallet user clusters into one Formo user. For other wallet providers, use the standard [React integration](#react--nextjs-without-wagmi). If your wallet provider uses Wagmi under the hood (many do, including Privy), you can also use the [Wagmi integration](#wagmi) for automatic wallet event tracking.
   </Accordion>
   <Accordion title="Why are my Solana wallet connections not showing up?">
     Wallet events are autocaptured on Solana only when your app passes a [framework-kit](#solana-with-framework-kit) store to `options.solana.store`. With `@solana/wallet-adapter`, Privy, Dynamic, Reown, or a custom connector there is no wallet state for the SDK to observe, so nothing is captured until you emit it yourself. See [Solana without framework-kit](#solana-without-framework-kit).

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -257,34 +257,26 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
 
     ```tsx
     import { useFormo } from '@formo/analytics';
-    import { usePrivy, useWallets } from '@privy-io/react-auth';
+    import { usePrivy } from '@privy-io/react-auth';
+    import { useAccount } from 'wagmi';
     import { useEffect } from 'react';
 
     function App() {
-      const { user } = usePrivy();
-      const { wallets, ready: walletsReady } = useWallets();
+      const { user } = usePrivy();       // null when the session isn't a Privy one
       const { address } = useAccount();  // plain wallet sessions
       const formo = useFormo();
 
-      // Depend on the address string, not the `wallets` array - useWallets()
-      // returns a new reference on many renders.
-      const activeAddress = address ?? wallets[0]?.address;
-
       useEffect(() => {
         if (!formo) return;
-        // Wait for Privy to finish discovering wallets: `user` can be ready
-        // first, and identifying in that window resolves no active address, so
-        // attribution falls back to user.wallet (usually the embedded wallet).
-        if (!walletsReady) return;
 
         // Check `user` first: a Privy session usually also has a wagmi
         // address, so testing the address first would lose the clustering.
         if (user) {
-          formo.identify(user, { activeAddress });
+          formo.identify(user);
         } else if (address) {
           formo.identify({ address });
         }
-      }, [user, address, formo, activeAddress, walletsReady]);
+      }, [user, address, formo]);
     }
     ```
 
@@ -1048,7 +1040,7 @@ A Privy user is **one account (a DID) with many linked wallets** - an embedded w
 `identify(user)` resolves this in a single call: it expands `user.linkedAccounts` and emits one identify per linked wallet, each tagged with the same Privy DID, so they cluster into one user.
 
 ```tsx
-formo.identify(user, { activeAddress });
+formo.identify(user);
 ```
 
 **What each wallet sends.** The shared profile parsed from `user.linkedAccounts` - `privyDid`, `privyCreatedAt`, `email`, `phone`, and socials (X, Discord, GitHub, Farcaster, Google, …) - plus that wallet's own `wallet_client`, `chain_type`, and `is_embedded`.

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -1054,6 +1054,20 @@ Linked wallets include `wallet` and `smart_wallet` accounts, plus a `cross_app` 
 Pass stable identity metadata in `properties`. A value that changes on every call (a timestamp, a random id) makes every identify a new event.
 </Note>
 
+**Apps with both Privy and non-Privy users.** Branch on which identity you have, checking `user` first — a Privy session usually also has a wagmi `address`, so testing the address first would send that user down the plain path and lose the clustering:
+
+```tsx
+useEffect(() => {
+  if (!formo) return;
+
+  if (user) {
+    formo.identify(user);            // every linked wallet, under the DID
+  } else if (address) {
+    formo.identify({ address });     // plain wallet connect
+  }
+}, [user, address, formo]);
+```
+
 For the framework-agnostic form, use `identifyPrivyUser(formo, user, options)` — the same behavior without the flag, available from the React-free `./core` entry.
 
 ## Proxy

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -1055,6 +1055,8 @@ formo.identify(user, { activeAddress });
 
 Linked wallets include `wallet` and `smart_wallet` accounts, plus a `cross_app` account's embedded and smart wallets (e.g. Abstract Global Wallet). Addresses are deduplicated.
 
+**Pinning the active wallet is optional.** `identify(user)` alone is enough for most apps: identify runs before the wagmi connect event on first load, so the active wallet may resolve to Privy's primary for a moment, but the effect re-runs once wallets load and attribution corrects itself. Pass `activeAddress` (and gate on `useWallets().ready`) only if you need attribution exact from the very first event, and note that gating means no identify at all until Privy reports ready.
+
 **Attribution.** Only one wallet owns the current address that later `track()` and `page()` events are attributed to. It's chosen in order: `activeAddress` if you pass it, else the wallet Formo already tracks from a prior connect, else Privy's `user.wallet`. The first two are matched strictly - a connected wallet that isn't linked in Privy is left alone rather than overwritten.
 
 **When identity re-emits.** Identify events are deduplicated per session on the wallet, the user id, and the profile, so:

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -268,7 +268,7 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
 
       // Depend on the address string, not the `wallets` array - useWallets()
       // returns a new reference on many renders.
-      const activeAddress = wallets[0]?.address;
+      const activeAddress = address ?? wallets[0]?.address;
 
       useEffect(() => {
         if (!formo) return;

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -282,7 +282,7 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
 
     `user` is reactive, so this re-runs on login and on every link/unlink.
 
-    See [Privy integration](#privy-integration) below for attribution rules, what each wallet sends, and when identity re-emits.
+    See [Privy integration](#privy-integration) below for what each wallet sends and how mixed Privy/non-Privy apps identify.
   </Tab>
   <Tab title="HTML Snippet">
     ```html
@@ -1043,22 +1043,6 @@ formo.identify(user);
 
 Linked wallets include `wallet` and `smart_wallet` accounts, plus a `cross_app` account's embedded and smart wallets (e.g. Abstract Global Wallet). Addresses are deduplicated.
 
-**Pinning the active wallet is optional.** `identify(user)` alone is enough for most apps: identify runs before the wagmi connect event on first load, so the active wallet may resolve to Privy's primary for a moment, but the effect re-runs once wallets load and attribution corrects itself. Pass `activeAddress` (and gate on `useWallets().ready`) only if you need attribution exact from the very first event, and note that gating means no identify at all until Privy reports ready.
-
-**Attribution.** Only one wallet owns the current address that later `track()` and `page()` events are attributed to. It's chosen in order: `activeAddress` if you pass it, else the wallet Formo already tracks from a prior connect, else Privy's `user.wallet`. The first two are matched strictly - a connected wallet that isn't linked in Privy is left alone rather than overwritten.
-
-**When identity re-emits.** Identify events are deduplicated per session on the wallet, the user id, and the profile, so:
-
-- re-running with the same user and profile is deduplicated - no spam on re-render;
-- a wallet identified anonymously re-emits once the Privy DID is attached at login;
-- **linking or unlinking a profile account re-emits every linked wallet** with the updated profile, since those properties are shared across the cluster.
-
-Unlinking is not retracted server-side. The effect re-runs for the remaining wallets, but no removal event is emitted, so an address that was already clustered stays clustered.
-
-<Note>
-Pass stable identity metadata in `properties`. A value that changes on every call (a timestamp, a random id) makes every identify a new event.
-</Note>
-
 **Apps with both Privy and non-Privy users.** Branch on which identity you have, checking `user` first - a Privy session usually also has a wagmi `address`, so testing the address first would send that user down the plain path and lose the clustering:
 
 ```tsx
@@ -1073,7 +1057,7 @@ useEffect(() => {
 }, [user, address, formo]);
 ```
 
-For the framework-agnostic form, use `identifyPrivyUser(formo, user, options)` - the same behavior without the flag, available from the React-free `./core` entry.
+`parsePrivyProperties(user)` returns the same parsed profile and wallet list without emitting, if you want to inspect or display what would be sent.
 
 ## Proxy
 

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -282,10 +282,6 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
 
     `user` is reactive, so this re-runs on login and on every link/unlink.
 
-    Wallet links are additive server-side: unlinking a wallet in Privy re-runs the effect for the remaining wallets, but the SDK emits no removal event, so an address that was already clustered stays clustered.
-
-    Only the active wallet takes over event attribution - `activeAddress` if you pass it, else the wallet Formo already tracks, else Privy's `user.wallet`. Every other linked wallet is recorded purely for clustering and never repoints attribution.
-
     See [Privy integration](#privy-integration) below for attribution rules, what each wallet sends, and when identity re-emits.
   </Tab>
   <Tab title="HTML Snippet">
@@ -1056,6 +1052,8 @@ Linked wallets include `wallet` and `smart_wallet` accounts, plus a `cross_app` 
 - re-running with the same user and profile is deduplicated - no spam on re-render;
 - a wallet identified anonymously re-emits once the Privy DID is attached at login;
 - **linking or unlinking a profile account re-emits every linked wallet** with the updated profile, since those properties are shared across the cluster.
+
+Unlinking is not retracted server-side. The effect re-runs for the remaining wallets, but no removal event is emitted, so an address that was already clustered stays clustered.
 
 <Note>
 Pass stable identity metadata in `properties`. A value that changes on every call (a timestamp, a random id) makes every identify a new event.

--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -263,23 +263,30 @@ If no parameters are specified, the Formo SDK will attempt to auto-identify the 
     function App() {
       const { user } = usePrivy();
       const { wallets } = useWallets();
+      const { address } = useAccount();  // plain wallet sessions
       const formo = useFormo();
 
-      // Depend on the address string, not the `wallets` array — useWallets()
+      // Depend on the address string, not the `wallets` array - useWallets()
       // returns a new reference on many renders.
       const activeAddress = wallets[0]?.address;
 
       useEffect(() => {
-        if (!user || !formo) return;
+        if (!formo) return;
 
-        formo.identify(user, { activeAddress });
-      }, [user, formo, activeAddress]);
+        // Check `user` first: a Privy session usually also has a wagmi
+        // address, so testing the address first would lose the clustering.
+        if (user) {
+          formo.identify(user, { activeAddress });
+        } else if (address) {
+          formo.identify({ address });
+        }
+      }, [user, address, formo, activeAddress]);
     }
     ```
 
     `user` is reactive, so this re-runs on login and on every link/unlink, keeping the identity graph current.
 
-    Only the active wallet takes over event attribution — `activeAddress` if you pass it, else the wallet Formo already tracks, else Privy's `user.wallet`. Every other linked wallet is recorded purely for clustering and never repoints attribution.
+    Only the active wallet takes over event attribution - `activeAddress` if you pass it, else the wallet Formo already tracks, else Privy's `user.wallet`. Every other linked wallet is recorded purely for clustering and never repoints attribution.
 
     See the [Privy integration guide](https://github.com/getformo/sdk/blob/main/docs/PRIVY_INTEGRATION.md) for attribution rules, what each wallet sends, and when identity re-emits.
   </Tab>
@@ -1030,7 +1037,7 @@ For Solana-only apps, set `evm: false` to disable EVM provider detection (EIP-11
 
 ### Privy integration
 
-A Privy user is **one account (a DID) with many linked wallets** — an embedded wallet plus any external wallets they connect over time. Because Formo is address-keyed, one person with 8 wallets would otherwise appear as 8 users.
+A Privy user is **one account (a DID) with many linked wallets** - an embedded wallet plus any external wallets they connect over time. Because Formo is address-keyed, one person with 8 wallets would otherwise appear as 8 users.
 
 `identify(user)` resolves this in a single call: it expands `user.linkedAccounts` and emits one identify per linked wallet, each tagged with the same Privy DID, so they cluster into one user.
 
@@ -1038,15 +1045,15 @@ A Privy user is **one account (a DID) with many linked wallets** — an embedded
 formo.identify(user, { activeAddress });
 ```
 
-**What each wallet sends.** The shared profile parsed from `user.linkedAccounts` — `privyDid`, `privyCreatedAt`, `email`, `phone`, and socials (X, Discord, GitHub, Farcaster, Google, …) — plus that wallet's own `wallet_client`, `chain_type`, and `is_embedded`.
+**What each wallet sends.** The shared profile parsed from `user.linkedAccounts` - `privyDid`, `privyCreatedAt`, `email`, `phone`, and socials (X, Discord, GitHub, Farcaster, Google, …) - plus that wallet's own `wallet_client`, `chain_type`, and `is_embedded`.
 
 Linked wallets include `wallet` and `smart_wallet` accounts, plus a `cross_app` account's embedded and smart wallets (e.g. Abstract Global Wallet). Addresses are deduplicated.
 
-**Attribution.** Only one wallet owns the current address that later `track()` and `page()` events are attributed to. It's chosen in order: `activeAddress` if you pass it, else the wallet Formo already tracks from a prior connect, else Privy's `user.wallet`. The first two are matched strictly — a connected wallet that isn't linked in Privy is left alone rather than overwritten.
+**Attribution.** Only one wallet owns the current address that later `track()` and `page()` events are attributed to. It's chosen in order: `activeAddress` if you pass it, else the wallet Formo already tracks from a prior connect, else Privy's `user.wallet`. The first two are matched strictly - a connected wallet that isn't linked in Privy is left alone rather than overwritten.
 
 **When identity re-emits.** Identify events are deduplicated per session on the wallet, the user id, and the profile, so:
 
-- re-running with the same user and profile is deduplicated — no spam on re-render;
+- re-running with the same user and profile is deduplicated - no spam on re-render;
 - a wallet identified anonymously re-emits once the Privy DID is attached at login;
 - **linking or unlinking a profile account re-emits every linked wallet** with the updated profile, since those properties are shared across the cluster.
 
@@ -1054,7 +1061,7 @@ Linked wallets include `wallet` and `smart_wallet` accounts, plus a `cross_app` 
 Pass stable identity metadata in `properties`. A value that changes on every call (a timestamp, a random id) makes every identify a new event.
 </Note>
 
-**Apps with both Privy and non-Privy users.** Branch on which identity you have, checking `user` first — a Privy session usually also has a wagmi `address`, so testing the address first would send that user down the plain path and lose the clustering:
+**Apps with both Privy and non-Privy users.** Branch on which identity you have, checking `user` first - a Privy session usually also has a wagmi `address`, so testing the address first would send that user down the plain path and lose the clustering:
 
 ```tsx
 useEffect(() => {
@@ -1068,7 +1075,7 @@ useEffect(() => {
 }, [user, address, formo]);
 ```
 
-For the framework-agnostic form, use `identifyPrivyUser(formo, user, options)` — the same behavior without the flag, available from the React-free `./core` entry.
+For the framework-agnostic form, use `identifyPrivyUser(formo, user, options)` - the same behavior without the flag, available from the React-free `./core` entry.
 
 ## Proxy
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — blocked on the SDK release.** This documents `identify(user, { privy: true })`, added in getformo/sdk#304 and not yet published. Merge once it ships as 1.34.0.

## Why

The Privy tab under **Identify users** currently teaches this:

```tsx
const { properties, wallets } = parsePrivyProperties(user);
for (const wallet of wallets) {
  formo.identify({ address: wallet.address, userId: user.id }, properties);
}
```

That pattern is actively harmful. The public `identify()` always promotes the wallet it's given to the SDK's current address, so the loop hands event attribution to **whichever wallet happens to be last** in `linkedAccounts` — typically the embedded wallet, not the one the user is actually transacting with.

## What changed

**Rewrote the Privy tab** to the one-liner, which identifies every linked wallet under the user's DID and promotes only the active one. The example also shows depending on the address string rather than the `useWallets()` array, which returns a new reference on most renders.

**Added a `### Privy integration` section** alongside the existing Wagmi and Solana sections, covering:

- what each wallet sends (shared profile + per-wallet `wallet_client`, `chain_type`, `is_embedded`)
- which accounts count as linked wallets, including `cross_app` embedded/smart wallets
- how the active wallet is resolved, and that a connected wallet not linked in Privy is left alone
- when identity re-emits — notably that linking or unlinking a profile account re-emits **every** linked wallet, since those properties are shared across the cluster
- a note to keep `properties` stable, since a volatile value makes every identify a new event

## Verified

The documented behavior was confirmed end to end against a live Privy app and a real Formo project: a 3-wallet user produced one identify per wallet sharing the DID and `anonymous_id`, attribution landed on the wagmi-active wallet, and linking X then Discord produced one re-emit per wallet each time with the socials propagating to all three addresses in `user_profiles_mv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788488397&installation_model_id=21031&pr_number=133&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F133&signature=0f52d1c2f1edcecba6c89f161cc68f277c77f32ad467f15d881db312486669ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getformo/docs.formo.so/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

