### PR TITLE
docs: document allowlists, Solana gating, and unique wallet addresses

### DIFF
--- a/features/token-gated-forms/token-gating.mdx
+++ b/features/token-gated-forms/token-gating.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Token gating'
-description: 'Restrict form access by requiring responders to hold specific ERC-20 tokens, NFTs, or complete identity verification before submitting responses.'
+description: 'Restrict form access by requiring responders to hold specific ERC-20 tokens, NFTs, or SPL tokens, be on an uploaded allowlist, or complete identity verification before submitting responses.'
 ---
 
 <Frame>
@@ -197,6 +197,97 @@ Contract Read supports any `view` or `pure` function that:
 
 Common use cases include `balanceOf`, `stakedBalance`, `getVotes`, `isWhitelisted`, `hasRole`, and any custom getter function on your contract.
 
+## Allowlist (CSV)
+
+Restrict a form to a fixed list of wallet addresses you upload as a CSV. Useful for private betas, investor updates, airdrop claims, and any form where the audience is a list you already hold rather than an onchain condition.
+
+Available on both **Connect Wallet (EVM)** and **Connect Wallet (Solana)**.
+
+### How it works
+
+Addresses are hashed in your browser, so the original allowlist is never stored anywhere and cannot be leaked. Only the hashes are uploaded — the plaintext addresses never leave your device, and Formo never holds your list.
+
+When someone opens your form, they connect and sign with their wallet to prove they own the address. Formo then checks that proven address against your uploaded list and re-checks it on the server when the response is submitted, so the gate can't be bypassed from the browser.
+
+### Setup
+
+<Steps>
+  <Step title="Save your form">
+    Save the form first — the allowlist is stored against it.
+  </Step>
+  <Step title="Enable a wallet requirement">
+    Turn on **Connect Wallet (EVM)** or **Connect Wallet (Solana)**. Keep the *Verify identity* condition it adds: the allowlist is checked against the wallet address that condition proves, so removing it blocks every submission.
+  </Step>
+  <Step title="Add the Allowlist condition">
+    Click **Add requirement** under that wallet requirement and select **Allowlist (CSV)**.
+  </Step>
+  <Step title="Upload your CSV">
+    Click **Upload CSV** and choose your file. Formo shows how many unique addresses it found.
+  </Step>
+  <Step title="Name and save">
+    Give the requirement a name (e.g. *Wallet is on the allowlist*) and save, then publish your form.
+  </Step>
+</Steps>
+
+### CSV format
+
+One wallet address per row, up to **100,000** addresses. Other columns and a header row are ignored, so a spreadsheet export works as-is:
+
+```csv
+wallet_address,notes
+0x7E6CA77a7E044BA836a97beB796c124Ca3a6A255,investor
+0x457AB1aacA14D6ADc2F109959AcB1A9B2B5EAe53,team
+```
+
+A bare list of addresses works equally well:
+
+```csv
+0x7E6CA77a7E044BA836a97beB796c124Ca3a6A255
+0x457AB1aacA14D6ADc2F109959AcB1A9B2B5EAe53
+```
+
+Duplicates are removed automatically, and rows without a valid address are skipped with a notice showing how many.
+
+<Tip>
+EVM addresses are matched case-insensitively, so checksummed and lowercase entries both work. Solana addresses are case-sensitive — paste them exactly as they appear.
+</Tip>
+
+### Updating the list
+
+Open the requirement and click **Replace CSV** to upload a new file. The previous list is discarded; there's no way to add to a list without re-uploading the full set, since Formo doesn't hold the original addresses.
+
+### Example
+
+| Field | Value |
+|-------|-------|
+| Type | Allowlist (CSV) |
+| Wallet requirement | Connect Wallet (EVM) |
+| Addresses | 2,500 uploaded from `investors.csv` |
+
+## Solana
+
+Alongside EVM chains, you can gate forms on Solana wallets. Enable **Connect Wallet (Solana)** in your form settings, then add one or more conditions:
+
+| Condition | Requires |
+|-----------|----------|
+| **Native Token** | A minimum SOL balance |
+| **SPL Token** | A minimum balance of an SPL token, by mint address |
+| **NFT** | An NFT from a specific collection |
+| **Allowlist (CSV)** | Membership of a list you upload (see [above](#allowlist-csv)) |
+
+Responders connect a Solana wallet (Phantom or Solflare) and sign a message to prove ownership before their balances are checked.
+
+### Setup
+
+1. In your form settings, enable **Connect Wallet (Solana)**
+2. Click **Add requirement** and choose a condition
+3. For SPL Token, paste the **token mint address** and set the **minimum balance**
+4. For NFT, paste the **collection address** and set the **minimum quantity**
+
+<Tip>
+EVM and Solana requirements can be combined on one form. Pair them with **Should meet some** if responders may hold assets on either ecosystem.
+</Tip>
+
 ## World ID
 
 Require responders to verify with World ID's proof-of-personhood check before submitting. See [World ID integration](/features/token-gated-forms/world-id) for setup.
@@ -251,3 +342,9 @@ Under **Access gating** in your form settings, choose how many requirements a re
 
 - **Should meet all** (default): responders must satisfy every requirement you've added
 - **Should meet some**: responders must satisfy at least N of your requirements, where you set N
+
+## Require unique wallet addresses
+
+Under a **Connect Wallet** requirement, enable **Require unique wallet addresses** to block the same wallet from submitting more than once. Use it for airdrops, claims, and one-vote-per-wallet forms.
+
+The equivalent toggle for World ID is **Require unique World ID**, which blocks the same verified human rather than the same wallet.

--- a/features/token-gated-forms/token-gating.mdx
+++ b/features/token-gated-forms/token-gating.mdx
@@ -260,41 +260,6 @@ Notice what the stored array does *not* contain: no addresses, and nothing that 
   </Step>
 </Steps>
 
-### CSV format
-
-One wallet address per row, up to **100,000** addresses. Other columns and a header row are ignored, so a spreadsheet export works as-is:
-
-```csv
-wallet_address,notes
-0x7E6CA77a7E044BA836a97beB796c124Ca3a6A255,investor
-0x457AB1aacA14D6ADc2F109959AcB1A9B2B5EAe53,team
-```
-
-A bare list of addresses works equally well:
-
-```csv
-0x7E6CA77a7E044BA836a97beB796c124Ca3a6A255
-0x457AB1aacA14D6ADc2F109959AcB1A9B2B5EAe53
-```
-
-Duplicates are removed automatically, and rows without a valid address are skipped with a notice showing how many.
-
-<Tip>
-EVM addresses are matched case-insensitively, so checksummed and lowercase entries both work. Solana addresses are case-sensitive, so paste them exactly as they appear.
-</Tip>
-
-### Updating the list
-
-Open the requirement and click **Replace CSV** to upload a new file. The previous list is discarded; there's no way to add to a list without re-uploading the full set, since Formo doesn't hold the original addresses.
-
-### Example
-
-| Field | Value |
-|-------|-------|
-| Type | Allowlist (CSV) |
-| Wallet requirement | Connect Wallet (EVM) |
-| Addresses | 2,500 uploaded from `investors.csv` |
-
 ## Solana
 
 Alongside EVM chains, you can gate forms on Solana wallets. Enable **Connect Wallet (Solana)** in your form settings, then add one or more conditions:

--- a/features/token-gated-forms/token-gating.mdx
+++ b/features/token-gated-forms/token-gating.mdx
@@ -205,15 +205,46 @@ Available on both **Connect Wallet (EVM)** and **Connect Wallet (Solana)**.
 
 ### How it works
 
-Addresses are hashed in your browser, so the original allowlist is never stored anywhere and cannot be leaked. Only the hashes are uploaded — the plaintext addresses never leave your device, and Formo never holds your list.
+Addresses are hashed in your browser, so the original allowlist is never stored anywhere and cannot be leaked. The plaintext addresses never leave your device, and Formo never holds your list.
 
 When someone opens your form, they connect and sign with their wallet to prove they own the address. Formo then checks that proven address against your uploaded list and re-checks it on the server when the response is submitted, so the gate can't be bypassed from the browser.
+
+Your browser turns the CSV into a **Bloom filter**, a compact bit array that can answer "is this address on the list?" without containing the addresses. Each address is hashed with a random salt unique to that list, and the resulting bits are combined into one array. Because the bits overlap between entries, the array can't be unpicked back into the addresses that produced it.
+
+Formo stores only that bit array, its salt, and the number of addresses you uploaded. A 100,000-address list is about 350 KB; your addresses appear nowhere in it.
+
+This makes the list cheap to check and impossible to read back, with one trade-off worth knowing: a Bloom filter never rejects someone who is on your list, but roughly **1 address in 1,000,000** that is *not* on your list may pass. For a typical allowlist that is a fraction of a single address. If you need an exact guarantee with no chance of a stranger passing, gate on token or NFT ownership instead.
+
+Here is a complete two-address allowlist. Each address is hashed with the list's salt, and the digest is split into two numbers that together pick the bit positions to set:
+
+```
+salt   4f2a9c71e08b3d6a5c1e7f90ab24d635
+
+0x7e6ca77a...a6a255
+  sha256(salt:address) = a4c5b2eabd59525c...
+  sets bits  0,1,6,7,11,12,17,18,23,24,29,30,35,36,41,42,46,47,52,53,58,59
+
+0x457ab1aa...5eae53
+  sha256(salt:address) = 2b8ed5586928b143...
+  sets bits  2,5,8,11,14,17,20,23,24,27,30,33,36,39,42,45,48,51,54,57,60,63
+```
+
+Those bits are merged into one array, and that array is the entire stored allowlist, eight bytes for this list:
+
+```
+hex     e75996699ae6799e
+binary  11100111 10011010 01101001 10010110 01011001 01100111 10011110 01111001
+```
+
+To check a wallet, Formo hashes it the same way and looks at the bits it points to. `0x0000...dEaD` points at bit 19, which is unset, so it is rejected immediately. A single unset bit proves the address was never added. Both of the addresses above find all of their bits set, so both pass.
+
+Notice what the stored array does *not* contain: no addresses, and nothing that can be turned back into them. Someone holding this row can only test addresses they already have, one at a time, and the random salt means work spent attacking one list is useless against any other.
 
 ### Setup
 
 <Steps>
   <Step title="Save your form">
-    Save the form first — the allowlist is stored against it.
+    Save the form first, since the allowlist is stored against it.
   </Step>
   <Step title="Enable a wallet requirement">
     Turn on **Connect Wallet (EVM)** or **Connect Wallet (Solana)**. Keep the *Verify identity* condition it adds: the allowlist is checked against the wallet address that condition proves, so removing it blocks every submission.
@@ -249,7 +280,7 @@ A bare list of addresses works equally well:
 Duplicates are removed automatically, and rows without a valid address are skipped with a notice showing how many.
 
 <Tip>
-EVM addresses are matched case-insensitively, so checksummed and lowercase entries both work. Solana addresses are case-sensitive — paste them exactly as they appear.
+EVM addresses are matched case-insensitively, so checksummed and lowercase entries both work. Solana addresses are case-sensitive, so paste them exactly as they appear.
 </Tip>
 
 ### Updating the list

--- a/features/token-gated-forms/token-gating.mdx
+++ b/features/token-gated-forms/token-gating.mdx
@@ -199,7 +199,7 @@ Common use cases include `balanceOf`, `stakedBalance`, `getVotes`, `isWhiteliste
 
 ## Allowlist (CSV)
 
-Restrict a form to a fixed list of wallet addresses you upload as a CSV. Useful for private betas, investor updates, airdrop claims, and any form where the audience is a list you already hold rather than an onchain condition.
+Restrict a form to a fixed list of wallet addresses you upload as a CSV. Useful for private betas, airdrop claims, and any form where the audience is a list you already hold rather than an onchain condition.
 
 Available on both **Connect Wallet (EVM)** and **Connect Wallet (Solana)**.
 


### PR DESCRIPTION
The token gating page listed only EVM token conditions. Three things responders can already be gated on were missing:

- Allowlist (CSV), including the CSV format, the browser-side hashing that keeps the list off our servers, and the fact that it must sit alongside a wallet requirement to have a proven address to test.
- Solana. The form builder page promises this page carries "the full list of requirement types", but SPL Token, Solana NFT and native SOL appeared nowhere.
- Require unique wallet addresses. Its World ID counterpart was documented; the wallet one was not.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788661003&installation_model_id=21031&pr_number=135&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F135&signature=6901328979c6160a65ec03308b061f51940c187cad383d6f6903cb1e86f3a75b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getformo/docs.formo.so/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

