### PR TITLE
Document profile property deletion via null values

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -5248,7 +5248,7 @@
       "put": {
         "operationId": "updateUserProperties",
         "summary": "Update user properties",
-        "description": "Set first-party properties for a wallet profile. Override display name, email, socials, avatar, location, and other identity fields.",
+        "description": "Set or unset first-party properties for a wallet profile. Override display name, email, socials, avatar, location, and other identity fields. Send `null` as a value to delete (unset) that property: the field then reads as null everywhere, including over any globally-enriched fallback value, until a new value is set. `user_id` cannot be unset (it participates in identity stitching). Set-and-unset compose in a single call. Note: profile enrichment snapshots are versioned, but first-party property overrides (and their deletions) are always current; a point-in-time read (`timestamp`) reflects the latest overrides, so a deletion also masks historical reads.",
         "tags": ["Profiles"],
         "parameters": [
           {
@@ -5267,7 +5267,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Merge-update of profile properties. Only the listed keys are accepted; unknown keys are rejected. At least one key must be provided.",
+                "description": "Merge-update of profile properties. Only the listed keys are accepted; unknown keys are rejected. At least one key must be provided. A `null` value unsets the property (not allowed for `user_id`). The literal string `__formo_deleted__` is a reserved internal tombstone and is rejected as a value.",
                 "minProperties": 1,
                 "additionalProperties": false,
                 "properties": {
@@ -5275,67 +5275,67 @@
                     "type": "string"
                   },
                   "display_name": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "email": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "farcaster": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "discord": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "twitter": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "telegram": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "instagram": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "website": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "github": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "linkedin": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "facebook": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "tiktok": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "youtube": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "reddit": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "avatar": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "description": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "location": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "ens": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "lens": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "basenames": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "linea": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   }
                 }
               },
@@ -5346,6 +5346,13 @@
                     "display_name": "alice.eth",
                     "email": "alice@example.com",
                     "twitter": "alice"
+                  }
+                },
+                "unsetProperties": {
+                  "summary": "Unset email, set a new display name",
+                  "value": {
+                    "display_name": "alice.eth",
+                    "email": null
                   }
                 }
               }
@@ -5389,7 +5396,7 @@
       "post": {
         "operationId": "batchUpdateUserProperties",
         "summary": "Batch update user properties",
-        "description": "Set first-party properties for up to 100 wallets in one request. Each item is a flat object with a required `address` (literal EVM `0x...` or Solana; ENS names are NOT resolved here) plus any of the allowed profile keys. Unknown keys are ignored; a row left with no valid keys, or with an invalid address, is quarantined (skipped and reported) rather than failing the batch. A request where every row is invalid returns 400. Requires profiles:write scope.",
+        "description": "Set first-party properties for up to 100 wallets in one request. Each item is a flat object with a required `address` (literal EVM `0x...` or Solana; ENS names are NOT resolved here) plus any of the allowed profile keys. A `null` value unsets (deletes) that property (`user_id` cannot be unset); the reserved tombstone string `__formo_deleted__` is rejected as a value. Unknown keys are ignored; a row left with no valid keys, or with an invalid address, is quarantined (skipped and reported) rather than failing the batch. A request where every row is invalid returns 400. Requires profiles:write scope.",
         "tags": ["Profiles"],
         "requestBody": {
           "required": true,
@@ -5401,7 +5408,7 @@
                 "maxItems": 100,
                 "items": {
                   "type": "object",
-                  "description": "Flat { address, ...keys } object. `address` is required; only the listed profile keys are persisted (all string-valued). Unknown keys are accepted but ignored.",
+                  "description": "Flat { address, ...keys } object. `address` is required; only the listed profile keys are persisted (string-valued, or null to unset; user_id cannot be unset). Unknown keys are accepted but ignored.",
                   "required": ["address"],
                   "additionalProperties": true,
                   "properties": {
@@ -5413,67 +5420,67 @@
                       "type": "string"
                     },
                     "display_name": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "email": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "farcaster": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "discord": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "twitter": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "telegram": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "instagram": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "website": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "github": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "linkedin": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "facebook": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "tiktok": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "youtube": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "reddit": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "avatar": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "description": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "location": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "ens": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "lens": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "basenames": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "linea": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     }
                   }
                 }
@@ -5726,7 +5733,7 @@
       "post": {
         "operationId": "batchUpsertUserLabels",
         "summary": "Batch add or update user labels",
-        "description": "Upsert up to 100 labels across many wallets in one request; each item carries its own `address`. Modelled on the events ingest API: rows with an invalid address (ENS names are NOT resolved here; pass a literal EVM `0x...` or Solana address) are quarantined (skipped and reported in the response) rather than failing the whole batch. A request where every row is invalid returns 400. Requires profiles:write scope.",
+        "description": "Upsert up to 100 labels across many wallets in one request; each item carries its own `address`. Modelled on the events ingest API: rows with an invalid address (ENS names are NOT resolved here; pass a literal EVM `0x...` or Solana address) are quarantined (skipped and reported in the response) rather than failing the whole batch. A request where every row is invalid returns 400. Requires profiles:write scope. Batch delete: send rows with `_is_deleted: 1` to tombstone labels in bulk; omit `timestamp` to delete as of now, or pair it with a past `timestamp` to record a historical removal (the equivalent of DELETE /v0/profiles/{address}/labels, one row per wallet/label).",
         "tags": ["Profiles"],
         "requestBody": {
           "required": true,

--- a/api/profiles/batch-update-properties.mdx
+++ b/api/profiles/batch-update-properties.mdx
@@ -1,5 +1,24 @@
 ---
 title: 'Batch Update Properties'
-description: 'Set first-party profile properties for up to 100 wallets in a single request. Each item is a flat object with a required address; unknown keys are ignored and invalid rows are quarantined rather than failing the whole batch.'
+description: 'Set or unset first-party profile properties for up to 100 wallets in a single request. Each item is a flat object with a required address; null values delete properties, unknown keys are ignored, and invalid rows are quarantined rather than failing the whole batch.'
 openapi: 'POST /v0/profiles/properties'
 ---
+
+## Deleting properties in a batch
+
+A `null` value deletes (unsets) that property, exactly as on the [single-wallet endpoint](/api/profiles/update-properties#deleting-properties). Set and unset can mix freely within and across rows:
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer <your_workspace_api_key>" \
+  -H "Content-Type: application/json" \
+  -d '[
+    { "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "display_name": "alice.eth", "email": null },
+    { "address": "EPjFWaYbrgqCC2Qbg4EV4FjUreEMKwMn1zNbiboXXKV", "twitter": null }
+  ]' \
+  "https://api.formo.so/v0/profiles/properties"
+```
+
+<Note>
+`user_id` cannot be unset (it participates in identity stitching); a row with `"user_id": null` fails request validation with [`400 BAD_REQUEST`](/api/errors#bad_request). The literal string `__formo_deleted__` is a reserved internal value and is rejected wherever a property value is accepted.
+</Note>

--- a/api/profiles/update-properties.mdx
+++ b/api/profiles/update-properties.mdx
@@ -1,5 +1,27 @@
 ---
 title: 'Update Properties'
-description: 'Merge-update profile properties for a wallet. Set display name, email, socials, avatar, location, and other identity fields via a single PUT request.'
+description: 'Merge-update profile properties for a wallet. Set display name, email, socials, avatar, location, and other identity fields, or send null to delete a property, via a single PUT request.'
 openapi: 'PUT /v0/profiles/{address}/properties'
 ---
+
+## Deleting properties
+
+Send `null` as a property value to delete (unset) it. Set and unset compose in a single call, and every key you did not mention is left untouched:
+
+```bash
+curl -sS -X PUT \
+  -H "Authorization: Bearer <your_workspace_api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "display_name": "alice.eth", "email": null }' \
+  "https://api.formo.so/v0/profiles/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045/properties"
+```
+
+A deleted property reads as `null` everywhere (profile reads, the Users table, search, and filters such as `notEmpty`), including over any globally-enriched fallback value, until a new value is set. One exception: a deleted `location` falls back to device geo rather than reading as absent.
+
+<Note>
+`user_id` cannot be unset; it participates in identity stitching, so `{ "user_id": null }` fails validation with [`400 BAD_REQUEST`](/api/errors#bad_request). The literal string `__formo_deleted__` is a reserved internal value and is rejected wherever a property value is accepted.
+</Note>
+
+<Note>
+Wallet-enrichment snapshots are versioned, but first-party property overrides (and their deletions) are always current. A point-in-time read with `timestamp` reflects the latest overrides, so a deletion also masks reads of snapshots taken before it.
+</Note>

--- a/cli/profiles.mdx
+++ b/cli/profiles.mdx
@@ -160,7 +160,7 @@ The vocabulary is shared, but each field implements a subset — an unsupported 
 
 ## `formo profiles update <address>`
 
-Merge-update identity properties on a single wallet profile.
+Merge-update identity properties on a single wallet profile. Provide `--properties`, `--unset`, or both.
 
 <Note>
 Requires `profiles:write` scope on your API key.
@@ -170,7 +170,8 @@ Requires `profiles:write` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--properties` | `string` | ✅ | JSON object of properties to merge |
+| `--properties` | `string` | One of the two | JSON object of properties to merge; a `null` value deletes (unsets) that property |
+| `--unset` | `string` | One of the two | Comma-separated property keys to delete, e.g. `email,twitter` (shorthand for `null` values in `--properties`) |
 
 Allowed property keys:
 
@@ -180,6 +181,20 @@ Allowed property keys:
 formo profiles update 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
   --properties '{"display_name":"Vitalik","twitter":"VitalikButerin"}'
 ```
+
+Delete properties by key, or mix set and unset in one call:
+
+```bash
+formo profiles update 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
+  --unset email,twitter
+
+formo profiles update 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
+  --properties '{"display_name":"alice.eth"}' --unset email
+```
+
+<Note>
+A deleted property reads as `null` everywhere, including over any globally-enriched fallback value, until a new value is set. `user_id` cannot be unset (it participates in identity stitching).
+</Note>
 
 ---
 
@@ -195,11 +210,18 @@ Requires `profiles:write` scope on your API key.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `--rows` | `string` | ✅ | JSON array of flat `{address, ...properties}` objects |
+| `--rows` | `string` | ✅ | JSON array of flat `{address, ...properties}` objects; a `null` value deletes (unsets) that property (`user_id` cannot be unset) |
 
 ```bash
 formo profiles properties batch \
   --rows '[{"address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","display_name":"alice.eth","email":"alice@example.com"}]'
+```
+
+Delete properties in a batch with `null` values:
+
+```bash
+formo profiles properties batch \
+  --rows '[{"address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","email":null}]'
 ```
 
 <Note>

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -95,11 +95,11 @@ Wallet enrichment and profile writes.
 | Tool | Description | Permission |
 |:-----|:------------|:-----------|
 | `search_profile` | Look up enrichment for a single wallet address (net worth, tokens, labels) | `profiles:read` |
-| `update_profile_properties` | Set profile properties on a wallet (address or ENS name) | `profiles:write` |
+| `update_profile_properties` | Set or unset profile properties on a wallet (address or ENS name); a `null` value deletes the property | `profiles:write` |
 | `upsert_profile_labels` | Add or update labels on a wallet | `profiles:write` |
 | `delete_profile_label` | Delete a label from a wallet | `profiles:write` |
-| `batch_update_profile_properties` | Set profile properties on up to 100 wallets in one call | `profiles:write` |
-| `batch_upsert_profile_labels` | Add or update labels on up to 100 wallets in one call | `profiles:write` |
+| `batch_update_profile_properties` | Set or unset profile properties on up to 100 wallets in one call; `null` values delete | `profiles:write` |
+| `batch_upsert_profile_labels` | Add, update, or delete labels on up to 100 wallets in one call (`_is_deleted: 1` rows tombstone) | `profiles:write` |
 | `import_wallets` | Import wallets as identified users (Scale and Enterprise plans; imported wallets count toward monthly active user billing) | `profiles:write` |
 
 ### Alerts


### PR DESCRIPTION
## Summary

Docs for profile property deletion, shipping in getformo/formono#2190 (API/MCP) and getformo/cli#47 (CLI).

- **`api/openapi.json`**: synced from the backend branch. `PUT /v0/profiles/{address}/properties` and `POST /v0/profiles/properties` now accept `null` values to unset properties; schemas widen to `["string", "null"]`, and the batch-labels description documents `_is_deleted: 1` bulk tombstones.
- **`api/profiles/update-properties.mdx` / `batch-update-properties.mdx`**: new prose sections covering deletion semantics: a deleted property reads as null everywhere including over globally-enriched fallback values, `user_id` cannot be unset (identity stitching), the `__formo_deleted__` tombstone is a reserved value, `location` falls back to device geo, and point-in-time reads reflect deletions (first-party overrides are not versioned).
- **`mcp/overview.mdx`**: tool table rows for `update_profile_properties`, `batch_update_profile_properties`, and `batch_upsert_profile_labels` now mention unset/delete.
- **`cli/profiles.mdx`**: documents the new `--unset` flag on `formo profiles update` and `null` rows in `formo profiles properties batch`.

## Dependencies

Merge after getformo/formono#2190 deploys (the API otherwise rejects null values) and getformo/cli#47 ships the `--unset` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788666839&installation_model_id=21031&pr_number=137&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F137&signature=0c90b36dd93b4e75a28f445da970f6d2f09c2a8813ad0dad7e7d978e5e338ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getformo/docs.formo.so/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

