### PR TITLE
docs: add the Scale field type to the form builder

### DIFF
--- a/features/token-gated-forms/form-builder.mdx
+++ b/features/token-gated-forms/form-builder.mdx
@@ -51,10 +51,12 @@ The form builder uses a drag-and-drop interface. Add fields by clicking the **+*
 | Category | Fields |
 |----------|--------|
 | **Basic** | Short Text, Long Text, Email, Link, Heading, Paragraph, Image |
-| **Advanced** | Single Choice, Dropdown, Checkboxes, File, Rating |
+| **Advanced** | Single Choice, Dropdown, Checkboxes, File, Rating, Scale |
 | **Verification** | Connect Wallet (EVM), Connect Wallet (Solana), Connect Discord, Connect X, Connect Telegram |
 
 A Connect Wallet field is required if you want to gate the form by token or NFT ownership. Connect Discord, Connect X, and Connect Telegram fields verify and capture the respective account.
+
+**Rating** shows a five-star widget. **Scale** shows a numeric scale with a configurable start, end, and step (0 to 10 by default), ideal for importance questions ("rate this from 1 to 5") and NPS-style surveys.
 
 ### Step 3: Enable token gating (optional)
 


### PR DESCRIPTION
## What

Adds the new **Scale** field to the form builder docs: listed in the Advanced field-type table and described in one line (numeric scale with configurable start, end, and step; 0 to 10 by default) alongside a clarification of Rating.

## Why

getformo/formono#2196 ships the Scale input type for forms; the field-type table on the form builder page was the only docs surface enumerating field types, so it needed the new entry.

Merge after (or together with) getformo/formono#2196 so docs don't lead the product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789001896&installation_model_id=21031&pr_number=139&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F139&signature=af1ff37822321ca3f3a71d2e8e2aae649b8e26f5a831637e16b47e296b3109cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getformo/docs.formo.so/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

