### PR TITLE
docs(web): make the Wagmi mode caveats prominent

### DIFF
--- a/sdks/web.mdx
+++ b/sdks/web.mdx
@@ -35,10 +35,17 @@ If you're already using [Wagmi](https://wagmi.sh), this is the recommended way t
 When `wagmi` options are provided, the SDK hooks directly into Wagmi's state management instead of wrapping EIP-1193 providers. This provides:
 - Native event handling via Wagmi's built-in state system
 - Better compatibility with wallet connection libraries (RainbowKit, ConnectKit, etc.)
-- Full tracking of signatures and transactions via TanStack Query's mutation cache
+- Tracking of signatures and transactions via TanStack Query's mutation cache
+- **Coverage of WalletConnect wallets**, which the EIP-1193 install methods cannot see at all
 
 Note that transaction and signature autocapture requires the use of [wagmi React hooks](#wagmi-integration).
 </Note>
+
+<Warning>
+**WalletConnect requires Wagmi mode.** The other install methods discover wallets through `window.ethereum` and [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) announcements. A WalletConnect provider uses neither: it is created inside the connector when the user connects, is never attached to the page's global scope, and never announces itself. No events of any kind are captured for those sessions.
+
+This affects every wallet that connects over WalletConnect, including **Ledger Live**, plus the Coinbase Wallet SDK popup, the MetaMask SDK on mobile, and Safe.
+</Warning>
 
 Install the Web SDK via NPM.
 
@@ -800,7 +807,30 @@ For apps using [Wagmi](https://wagmi.sh), enable native integration by providing
 ```
 
 <Warning>
-Transaction and signature autocapture requires the use of [wagmi React hooks](https://wagmi.sh/react/api/hooks) (`useWriteContract`, `useSendTransaction`, `useSignMessage`). Calls via `@wagmi/core` or viem directly bypass the mutation cache and won't be tracked. If you are not using these hooks, use the non-wagmi React or Next.js installation methods instead.
+**Transaction and signature autocapture requires [wagmi React hooks](https://wagmi.sh/react/api/hooks)** (`useWriteContract`, `useSendTransaction`, `useSignMessage`). The SDK reads these from TanStack Query's mutation cache. Calls made through `@wagmi/core` or a viem wallet client directly never reach that cache, so they produce no events.
+
+Check before you switch. If your app sends transactions from a plain module rather than a hook, for example a shared `sendTransaction` util that calls `walletClient.request(...)`, Wagmi mode captures **no** transaction or signature events.
+</Warning>
+
+<Warning>
+**Migrating from an EIP-1193 install method?** Wagmi mode replaces provider wrapping, it does not run alongside it. If your app does not use the wagmi hooks above, enabling Wagmi mode will **stop** the transaction and signature events you are getting today, while adding WalletConnect connection coverage.
+
+If that applies to you, keep the connection coverage and re-add the two event types explicitly at your own send and sign call sites:
+
+```ts
+import { TransactionStatus } from '@formo/analytics';
+
+analytics?.transaction({
+  status: TransactionStatus.BROADCASTED,
+  chainId,
+  address: account,
+  to: contractAddress,
+  data: callData,
+  transactionHash: hash,
+});
+```
+
+See [`transaction`](/data/events/transaction) and [`signature`](/data/events/signature) for the full parameter list.
 </Warning>
 
 When Wagmi mode is enabled, the SDK:


### PR DESCRIPTION
Two caveats in the Web SDK docs were easy to miss, and both cost a customer real data. This makes them explicit at the two points where someone actually chooses an install method.

## 1. WalletConnect requires Wagmi mode

The EIP-1193 install methods discover wallets through `window.ethereum` and EIP-6963 announcements. Both are **browser-extension** mechanisms: a content script runs at `document_start` and either assigns the global or dispatches an announcement.

A WalletConnect provider does neither. It is constructed by library code inside the page when the user clicks Connect, it is never attached to the global scope, and it never announces itself. Verified against `@walletconnect/ethereum-provider` 2.21.1: **zero** EIP-6963 references in the ESM and CJS builds (the only hits are bundled Reown constant tables in the UMD build).

The provider does emit `connect`, `accountsChanged`, `chainChanged`, and `disconnect` — but on its own EventEmitter, never on `window` (zero `window.dispatchEvent` calls). Without a reference to the object there is nothing to subscribe to. So no events of any kind are captured for those sessions.

Same shape for the Coinbase Wallet SDK popup, the MetaMask SDK on mobile, Safe, and Porto. All verified as non-announcing.

## 2. Wagmi mode replaces provider wrapping, it does not run alongside it

The existing hooks warning stated the rule but not the consequence. An app that sends transactions from a plain module — a shared `sendTransaction` util calling `walletClient.request(...)` — gets full transaction and signature coverage today via provider wrapping, and **loses all of it** on switching to Wagmi mode, because imperative `@wagmi/core` and viem calls never reach TanStack Query's mutation cache.

Adds a migration warning with the explicit `transaction()` escape hatch and links to the `transaction` and `signature` event references.

## Changes

- New Warning in `### Wagmi` covering WalletConnect discovery
- Sharpened the hooks Warning in `### Wagmi integration` with the concrete failure shape
- New migration Warning for anyone moving off an EIP-1193 install method
- Added WalletConnect coverage to the Wagmi mode benefits list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789195325&installation_model_id=21031&pr_number=140&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F140&signature=53415f6cfeb865c3ac5acfb56c68d7be50e8f3d4b0d27377009b1684706910e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getformo/docs.formo.so/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

