### PR TITLE
docs: reorder user lifecycle stages to follow the journey

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Guidance for AI agents working in this repository (the Formo docs site, built wi
 
 Define each concept once and link to it elsewhere rather than restating the details (which drift out of sync).
 
-- **User lifecycle stages** (New, Returning, Power User, Resurrected, Churned): the authoritative definition with exact rules and thresholds lives in `features/wallet-intelligence/wallet-profiles.mdx` (`#user-lifecycle`). Other pages should give a brief, contextual mention and link to it. The SQL-oriented restatement in `data/catalog.mdx` is the one allowed exception, since it serves query writers in-context.
+- **User lifecycle stages** (New, Returning, Power user, At Risk, Churned, Resurrected): the authoritative definition with exact rules and thresholds lives in `features/wallet-intelligence/wallet-profiles.mdx` (`#user-lifecycle`). Other pages should give a brief, contextual mention and link to it. The SQL-oriented restatement in `data/catalog.mdx` is the one allowed exception, since it serves query writers in-context.
 
 ## API reference
 

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1117,9 +1117,9 @@
               "New",
               "Returning",
               "Power user",
-              "Resurrected",
               "At Risk",
-              "Churned"
+              "Churned",
+              "Resurrected"
             ]
           },
           "num_sessions": {
@@ -7498,7 +7498,7 @@
     "/v0/lifecycle": {
       "get": {
         "operationId": "getAnalyticsLifecycle",
-        "summary": "Get user lifecycle stages (New / Returning / Power user / Resurrected / At Risk / Churned)",
+        "summary": "Get user lifecycle stages (New / Returning / Power user / At Risk / Churned / Resurrected)",
         "description": "Counts wallet users by lifecycle stage based on activity within the date range. The reference date is `date_to`.\n\nDefault stage thresholds can be overridden per-request with the lifecycle threshold query params (`new_window_days`, `churn_window_days`, `power_user_min_active_days`, `power_user_window_days`, `resurrected_gap_days`, `at_risk_min_days_inactive`, `at_risk_prior_active_days_threshold`); each is an optional integer 1 to 90. When omitted, the project's saved Settings → Lifecycle values apply, then the platform defaults.",
         "tags": ["Query"],
         "x-required-scope": "query:read",
@@ -7587,11 +7587,6 @@
                     },
                     {
                       "project_id": "proj_abc",
-                      "user_type": "Resurrected",
-                      "user_count": 11
-                    },
-                    {
-                      "project_id": "proj_abc",
                       "user_type": "At Risk",
                       "user_count": 14
                     },
@@ -7599,6 +7594,11 @@
                       "project_id": "proj_abc",
                       "user_type": "Churned",
                       "user_count": 142
+                    },
+                    {
+                      "project_id": "proj_abc",
+                      "user_type": "Resurrected",
+                      "user_count": 11
                     }
                   ],
                   "rows": 6,

--- a/api/profiles/get.mdx
+++ b/api/profiles/get.mdx
@@ -161,9 +161,9 @@ Possible lifecycle values:
 - `New` - Recently acquired user
 - `Returning` - User who has returned after absence
 - `Power user` - Highly active user
-- `Resurrected` - User who returned after long absence
 - `At Risk` - Established user who is still active but going quiet
 - `Churned` - User who has stopped engaging
+- `Resurrected` - User who returned after long absence
 
 ### Social & Identity
 

--- a/api/profiles/search.mdx
+++ b/api/profiles/search.mdx
@@ -257,7 +257,7 @@ Filter by user engagement and profile data. Use the format `users.{attribute}`.
 
 #### Lifecycle Filter
 
-Filter by user lifecycle stage. Valid values: `At Risk`, `Churned`, `New`, `Power user`, `Resurrected`, `Returning`.
+Filter by user lifecycle stage. Valid values: `New`, `Returning`, `Power user`, `At Risk`, `Churned`, `Resurrected`.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -710,7 +710,7 @@ Each profile in the `data` array includes:
 | `tx_count` | integer | Total transaction count |
 | `first_onchain` | string | First on-chain activity timestamp (ISO 8601) |
 | `last_onchain` | string | Last on-chain activity timestamp (ISO 8601) |
-| `lifecycle` | string | User lifecycle stage: `At Risk`, `Churned`, `New`, `Power user`, `Resurrected`, `Returning` |
+| `lifecycle` | string | User lifecycle stage: `New`, `Returning`, `Power user`, `At Risk`, `Churned`, `Resurrected` |
 | `ens` | string \| null | ENS name |
 | `farcaster` | string \| null | Farcaster username |
 | `twitter` | string \| null | Twitter/X handle |

--- a/api/query/user-lifecycle.mdx
+++ b/api/query/user-lifecycle.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Get User Lifecycle"
-description: "Wallet user counts by lifecycle stage (New, Returning, Power user, Resurrected, At Risk, Churned)."
+description: "Wallet user counts by lifecycle stage (New, Returning, Power user, At Risk, Churned, Resurrected)."
 openapi: "GET /v0/lifecycle"
 ---
 

--- a/cli/analytics.mdx
+++ b/cli/analytics.mdx
@@ -22,7 +22,7 @@ Requires `query:read` scope on your API key.
 | `funnel` | Conversion funnel across ordered steps |
 | `flow` | User path / flow analysis between steps |
 | `frequency` | Engagement frequency distribution |
-| `lifecycle` | User lifecycle stages (new, returning, power, resurrected, at risk, churned) |
+| `lifecycle` | User lifecycle stages (new, returning, power, at risk, churned, resurrected) |
 | `retention` | Retention cohort analysis |
 | `revenue_overview` | Revenue overview with optional breakdown |
 | `revenue_by_metric` | Revenue ranked by a metric column |

--- a/data/catalog.mdx
+++ b/data/catalog.mdx
@@ -183,11 +183,11 @@ This is an **aggregate table**. Most columns require `-Merge` functions. Always 
 
 **Lifecycle definitions** (based on `activity_dates`, computed against a reference date that defaults to today):
 - **New**: `first_seen` within the last 30 days and still active
+- **Returning**: default (first seen more than 30 days ago, active recently, but not Power, At Risk, or Resurrected)
 - **Power**: `first_seen` more than 30 days ago and 5+ unique active days in the last 30 days
-- **Resurrected**: `first_seen` more than 30 days ago and re-engaged within the last 30 days after a 30+ day gap
 - **At Risk**: `first_seen` more than 30 days ago, still active, but `last_seen` 14+ days ago with fewer than 5 active days in the last 30 days, no 30+ day gap, and 1+ active day in the prior window (days 30 to 60 ago)
 - **Churned**: `last_seen` more than 30 days ago
-- **Returning**: default (first seen more than 30 days ago, active recently, but not Power, Resurrected, or At Risk)
+- **Resurrected**: `first_seen` more than 30 days ago and re-engaged within the last 30 days after a 30+ day gap
 
 **Example:**
 

--- a/data/metrics.mdx
+++ b/data/metrics.mdx
@@ -145,7 +145,7 @@ The most recent date and time when a user or wallet was observed interacting wit
 
 ### User lifecycle
 
-The lifecycle stage of each wallet or visitor (New, Returning, Power user, Resurrected, At Risk, or Churned), computed from their activity recency and frequency relative to a reference date.
+The lifecycle stage of each wallet or visitor (New, Returning, Power user, At Risk, Churned, or Resurrected), computed from their activity recency and frequency relative to a reference date.
 
 See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds for each stage.
 
@@ -157,10 +157,6 @@ Users who visit your site or app for the first time within the selected time per
 
 Users who have visited your site or app in previous time periods and return within the current period.
 
-### Resurrected Users
-
-Users who were previously active, became inactive for a period of time, and then return after being inactive.
-
 ### At Risk Users
 
 Previously active users whose activity has slowed but who haven't churned yet: last seen at least 14 days ago, fewer than 5 active days in the last 30 days, and no 30+ day gap, with at least 1 active day in the prior 30 to 60 days.
@@ -168,6 +164,10 @@ Previously active users whose activity has slowed but who haven't churned yet: l
 ### Churned Users
 
 Users with no activity within the project's churn window.
+
+### Resurrected Users
+
+Users who were previously active, became inactive for a period of time, and then return after being inactive.
 
 ### Events
 

--- a/features/product-analytics/alerts.mdx
+++ b/features/product-analytics/alerts.mdx
@@ -351,7 +351,7 @@ The webhook payload uses the `alert.user.triggered` event type:
 | `revenue` | number | Total revenue |
 | `volume` | number | Total transaction volume |
 | `points` | number | Total loyalty points |
-| `lifecycle` | string | Lifecycle stage (`New`, `Returning`, `Power user`, `Resurrected`, `At Risk`, `Churned`) |
+| `lifecycle` | string | Lifecycle stage (`New`, `Returning`, `Power user`, `At Risk`, `Churned`, `Resurrected`) |
 | `activity_dates` | string[] | Array of dates the user was active |
 | `location` | string | Country code |
 | `device` | string | Device type |

--- a/features/wallet-intelligence/audience-insights.mdx
+++ b/features/wallet-intelligence/audience-insights.mdx
@@ -26,7 +26,7 @@ Apply filters to understand how different segments of users interact with your a
 
 ### Filter by Lifecycle
 
-Filter users by their [lifecycle stage](/features/wallet-intelligence/wallet-profiles#user-lifecycle) to create segments: New, Power User, Resurrected, At Risk, Returning, Churned.
+Filter users by their [lifecycle stage](/features/wallet-intelligence/wallet-profiles#user-lifecycle) to create segments: New, Returning, Power user, At Risk, Churned, Resurrected.
 
 ### Filter by Apps, Tokens, Chains
 
@@ -60,7 +60,7 @@ The dashboard shows key breakdowns of your audience:
 
 | Chart | What it shows |
 |-------|---------------|
-| **Lifecycle** | New, Returning, Power user, Resurrected, At Risk, Churned breakdown |
+| **Lifecycle** | New, Returning, Power user, At Risk, Churned, Resurrected breakdown |
 | **Sessions per Wallet** | Distribution of session counts across your users |
 | **Transactions per Wallet** | Distribution of transaction counts across your users |
 | **Net Worth Distribution** | Users grouped by wallet value ($0-$250, $250-$10K, $10K-$50K, $50K-$100K, $100K-$500K, $500K-$1M, $1M-$5M, $5M-$10M, $10M-$25M, $25M-$50M, $50M-$100M, $100M+) |

--- a/features/wallet-intelligence/overview.mdx
+++ b/features/wallet-intelligence/overview.mdx
@@ -63,9 +63,9 @@ Formo automatically categorizes users by lifecycle stage based on their activity
 | **New** | Recent acquisition |
 | **Returning** | Engaged user |
 | **Power user** | Highly engaged |
-| **Resurrected** | Re-engaged after going quiet |
 | **At Risk** | Still active but going quiet |
 | **Churned** | Needs re-engagement |
+| **Resurrected** | Re-engaged after going quiet |
 
 Use the lifecycle filter on the Users page to focus on specific user groups.
 

--- a/features/wallet-intelligence/segments.mdx
+++ b/features/wallet-intelligence/segments.mdx
@@ -30,7 +30,7 @@ You can use <a href="/features/wallet-intelligence/wallet-labels">wallet labels<
 
 ## Lifecycle Segments
 
-Each user's lifecycle stage is automatically calculated based on their activity. Filter users by lifecycle (New, Power User, Resurrected, At Risk, Returning, Churned) to create segments and audiences.
+Each user's lifecycle stage is automatically calculated based on their activity. Filter users by lifecycle (New, Returning, Power user, At Risk, Churned, Resurrected) to create segments and audiences.
 
 See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for a breakdown of the different lifecycle stages.
 

--- a/features/wallet-intelligence/wallet-labels.mdx
+++ b/features/wallet-intelligence/wallet-labels.mdx
@@ -17,7 +17,7 @@ Each tracked user on Formo is assigned labels based on their onchain activity an
 
 ### User lifecycle labels
 
-Every wallet is assigned a lifecycle stage based on its recency and active days: **New**, **Returning**, **Power user**, **Resurrected**, **At Risk**, or **Churned**. See [User lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
+Every wallet is assigned a lifecycle stage based on its recency and active days: **New**, **Returning**, **Power user**, **At Risk**, **Churned**, or **Resurrected**. See [User lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
 
 ### Attestations
 

--- a/features/wallet-intelligence/wallet-profiles.mdx
+++ b/features/wallet-intelligence/wallet-profiles.mdx
@@ -24,11 +24,11 @@ Each user's lifecycle stage is computed relative to a **reference date** (the en
 | Lifecycle | Definition |
 |:----------|:------------|
 | **New** | First seen within the last 30 days and still active. |
+| **Returning** | Established active users who don't fit another stage: active recently but not New, Power, At Risk, or Resurrected. |
 | **Power user** | First seen more than 30 days ago, still active, and active on at least 5 distinct days in the last 30 days. |
-| **Resurrected** | First seen more than 30 days ago and re-engaged within the last 30 days after a 30+ day inactivity gap. |
 | **At Risk** | Previously active wallet whose activity has slowed but that hasn't churned yet: last seen at least 14 days ago, fewer than 5 active days in the last 30 days, and no 30+ day gap, with at least 1 active day in the prior 30 to 60 days. |
-| **Returning** | Established active users who don't fit another stage: active recently but not New, Power, Resurrected, or At Risk. |
 | **Churned** | Last seen at least 30 days ago. |
+| **Resurrected** | First seen more than 30 days ago and re-engaged within the last 30 days after a 30+ day inactivity gap. |
 
 Stages are mutually exclusive and evaluated in precedence order: Churned, New, Power user, Resurrected, At Risk, Returning. **At Risk** carves out fading users that would otherwise sit in Returning, surfacing established wallets to re-engage before they churn.
 
@@ -159,7 +159,7 @@ The profile header shows key information at a glance:
 | **Address** | Wallet address with copy button |
 | **ENS** | ENS name, if resolved (falls back to a shortened address) |
 | **Net Worth** | Total value across all chains |
-| **Lifecycle** | New, Returning, Power user, Resurrected, At Risk, or Churned |
+| **Lifecycle** | New, Returning, Power user, At Risk, Churned, or Resurrected |
 | **First Seen** | When they first visited your app |
 | **Last Seen** | Most recent activity |
 

--- a/guides/dau-tracking.mdx
+++ b/guides/dau-tracking.mdx
@@ -141,7 +141,7 @@ Not all active users are equal. Segment by behavior and value.
 
 Formo automatically categorizes users by lifecycle:
 
-Formo classifies every wallet into one lifecycle stage (**New**, **Returning**, **Power user**, **Resurrected**, **At Risk**, or **Churned**) based on activity recency and frequency. See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
+Formo classifies every wallet into one lifecycle stage (**New**, **Returning**, **Power user**, **At Risk**, **Churned**, or **Resurrected**) based on activity recency and frequency. See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
 
 View these segments by going to **Users** and applying the **Lifecycle** filter.
 

--- a/guides/retention.mdx
+++ b/guides/retention.mdx
@@ -94,7 +94,7 @@ Once saved, you can export this segment as CSV for re-engagement campaigns or us
 </Frame>
 
 <Note>
-**User Lifecycle Stages:** New, Returning, Power user, Resurrected, At Risk, and Churned, assigned from each wallet's activity recency and frequency. See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
+**User Lifecycle Stages:** New, Returning, Power user, At Risk, Churned, and Resurrected, assigned from each wallet's activity recency and frequency. See [User Lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) for the exact rules and thresholds.
 
 Use these stages to build segments for targeted campaigns.
 </Note>

--- a/guides/sql-explorer.mdx
+++ b/guides/sql-explorer.mdx
@@ -225,7 +225,7 @@ FROM (
 GROUP BY user_type
 ```
 
-This is a simple session-count split. Formo's built-in [user lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) (New, Returning, Power user, Resurrected, At Risk, Churned) uses recency and active days instead.
+This is a simple session-count split. Formo's built-in [user lifecycle](/features/wallet-intelligence/wallet-profiles#user-lifecycle) (New, Returning, Power user, At Risk, Churned, Resurrected) uses recency and active days instead.
 
 ### Query 8: Whale Analysis
 

--- a/guides/wallet-segmentation.mdx
+++ b/guides/wallet-segmentation.mdx
@@ -21,7 +21,7 @@ Each row is a wallet. Every column is filterable. This is your segmentation star
 
 Click the **Filter** button to add conditions. You can filter by:
 
-- **Lifecycle**: New, Returning, Power user, Resurrected, At Risk, Churned
+- **Lifecycle**: New, Returning, Power user, At Risk, Churned, Resurrected
 - **Net Worth**: Exact ranges ($0-$10k, $10k-$100k, $100k+, custom)
 - **Wallet Labels**: Verified accounts, sanctions flags, passport scores
 - **Apps Used**: Filter to users who used specific apps

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -71,7 +71,7 @@ Permission: `query:read`.
 | `distinct_values` | Get unique values for filtering |
 | `top_events` | View most common events |
 | `event_timeseries` | Event counts over time |
-| `lifecycle` | Lifecycle stage breakdown (new, returning, power, resurrected, at risk, churned) |
+| `lifecycle` | Lifecycle stage breakdown (new, returning, power, at risk, churned, resurrected) |
 | `retention` | User retention by cohort |
 | `frequency` | How often users return |
 | `project_users` | Row-level user list, filterable by lifecycle stage, token holdings, and more |


### PR DESCRIPTION
Present lifecycle stages in journey order everywhere they are listed: New, Returning, Power user, At Risk, Churned, Resurrected. Previously pages listed them in mixed orders (New/Power/Resurrected/At Risk/ Returning/Churned in the main table, alphabetical in the API reference, and other variants elsewhere).

Reorders the authoritative table in wallet-profiles.mdx plus every other listing: guides, data catalog and metrics, CLI and MCP references, API reference pages, and the openapi.json enum, endpoint summary, and sample response. Also normalizes "Power User" to the canonical "Power user" where it had drifted, and adds the missing At Risk stage to the CLAUDE.md single-source-of-truth note.

The precedence order sentence in wallet-profiles.mdx is left unchanged, since it documents how stages are evaluated rather than how they display.


Claude-Session: https://claude.ai/code/session_011sXQtcrHyv7SDkutCWxvDZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/docs.formo.so/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789196346&installation_model_id=21031&pr_number=141&repository=getformo%2Fdocs.formo.so&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fdocs.formo.so%2Fpull%2F141&signature=40b6a248d92548cb705a9a7bf093c3028c494e0a22c3751602f13db6c5deb67c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getformo/docs.formo.so/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

